### PR TITLE
Fix client naming in dev-guide

### DIFF
--- a/dev-guide/credential-providers.md
+++ b/dev-guide/credential-providers.md
@@ -25,7 +25,7 @@ Not all credential providers are supported yet by the experimental Amazon Bedroc
 To use a specific credentials identity resolver, set the `aws_credentials_identity_resolver` property on the service client's `Config` object to an instance of the credentials identity resolver class you want to use. The following example specifically uses the `EnvironmentCredentialsResolver()`, which fetches credentials from the standard environment variables `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN`.
 
 ```
-    service_client = BedrockRuntime(
+    service_client = BedrockRuntimeClient(
         config=Config(
             aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
             region = "us-east-1",

--- a/dev-guide/region.md
+++ b/dev-guide/region.md
@@ -10,7 +10,7 @@ Most resources reside in a specific AWS Region and you must supply the correct R
 The Region is specified by setting the `region` property of the `Config` object to a string giving the name of the Region. For example, to specify the region `us-east-1` when creating an Amazon Bedrock Runtime client:
 
 ```
-    service_client = BedrockRuntime(
+    service_client = BedrockRuntimeClient(
         config=Config(
             aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
             region = "us-east-1",
@@ -31,7 +31,7 @@ import os
 ...
 region = os.getenv('AWS_REGION', default="us-east-1")
     
-service_client = BedrockRuntime(
+service_client = BedrockRuntimeClient(
     config=Config(
         aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
         region = region,

--- a/dev-guide/service-clients.md
+++ b/dev-guide/service-clients.md
@@ -3,7 +3,7 @@
 To make a request to an AWS service, you first instantiate a client for that service. You can configure common settings for service clients such as timeouts, the HTTP client, and retry configuration. To create a client for Amazon Bedrock Runtime:
 
 ```
-    service_client = BedrockRuntime(
+    service_client = BedrockRuntimeClient(
         config=Config(
             aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
             region = "us-east-1",

--- a/dev-guide/simple-app.md
+++ b/dev-guide/simple-app.md
@@ -7,7 +7,7 @@ This chapter features a short example that asks the Amazon Titan Text Express ge
 The first thing our program does is import the service and the types we need from it:
 
 ```
-from aws_sdk_bedrock_runtime.client import BedrockRuntime, ConverseInput
+from aws_sdk_bedrock_runtime.client import BedrockRuntimeClient, ConverseInput
 from aws_sdk_bedrock_runtime.models import Message, ContentBlockText, StopReason
 from aws_sdk_bedrock_runtime.config import Config
 
@@ -18,7 +18,7 @@ import asyncio
 
 This imports the following from the Bedrock client:
 
-1. `BedrockRuntime`, which is the class representing the Amazon Bedrock Runtime client.
+1. `BedrockRuntimeClient`, which is the class representing the Amazon Bedrock Runtime client.
 
 1. The `ConverseInput` class, which is used to specify the input values when calling the client's `converse()` function.
 
@@ -38,11 +38,11 @@ Also imported is the `asyncio` package, which is used to manage the asynchronous
 
 ## Creating the Amazon Bedrock Runtime client<a name="simple-app-create-client"></a>
 
-To create the Amazon Bedrock Runtime client, create a `BedrockRuntime` instance using a `Config` object providing the AWS Region to use. In this example, a credentials identity resolver is provided that uses the standard AWS [access keys in environment variables](https://docs.aws.amazon.com/sdkref/latest/guide/access-users.html) are used to specify credentials. 
+To create the Amazon Bedrock Runtime client, create a `BedrockRuntimeClient` instance using a `Config` object providing the AWS Region to use. In this example, a credentials identity resolver is provided that uses the standard AWS [access keys in environment variables](https://docs.aws.amazon.com/sdkref/latest/guide/access-users.html) are used to specify credentials.
 
 ```
 def get_service_client():
-    service_client = BedrockRuntime(
+    service_client = BedrockRuntimeClient(
         config=Config(
             aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
             region = "us-east-1",


### PR DESCRIPTION
*Description of changes:*
Initial dev-guide submission has misnamed client imports/references. This PR will bring them inline with the published client.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
