### PR TITLE
Add changelog for aws_sdk_bedrock_runtime v0.0.2

### DIFF
--- a/clients/aws-sdk-bedrock-runtime/CHANGES.md
+++ b/clients/aws-sdk-bedrock-runtime/CHANGES.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.0.2
+
+### Dependencies
+
+* Updated support for all smithy dependencies in the 0.0.x minor version.
+
 ## v0.0.1
 
 ### Features

--- a/clients/aws-sdk-bedrock-runtime/pyproject.toml
+++ b/clients/aws-sdk-bedrock-runtime/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "aws_sdk_bedrock_runtime"
-version = "0.0.1"
+version = "0.0.2"
 description = "aws_sdk_bedrock_runtime client"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -23,11 +23,11 @@ classifiers = [
 ]
 
 dependencies = [
-    "smithy_aws_core==0.0.1",
-    "smithy_aws_event_stream==0.0.1",
-    "smithy_core==0.0.1",
-    "smithy_http[awscrt]==0.0.1",
-    "smithy_json==0.0.1"
+    "smithy_aws_core<0.1.0",
+    "smithy_aws_event_stream<0.1.0",
+    "smithy_core<0.1.0",
+    "smithy_http[awscrt]<0.1.0",
+    "smithy_json<0.1.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
*Description of changes:*
This release adds support for everything in the current minor version of releases in Smithy. This will allow incremental updates and bugfixes without requiring a new release of the `aws_sdk_bedrock_runtime` client each time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
