### PR TITLE
Add bedrock-runtime model for reproducible builds

### DIFF
--- a/codegen/aws-models/bedrock-runtime.json
+++ b/codegen/aws-models/bedrock-runtime.json
@@ -1,0 +1,5689 @@
+{
+    "smithy": "2.0",
+    "shapes": {
+        "com.amazonaws.bedrockruntime#AccessDeniedException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.bedrockruntime#NonBlankString"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The request is denied because you do not have sufficient permissions to perform the requested action. For troubleshooting this error, \n         see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/troubleshooting-api-error-codes.html#ts-access-denied\">AccessDeniedException</a> in the Amazon Bedrock User Guide</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 403
+            }
+        },
+        "com.amazonaws.bedrockruntime#AccountId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#pattern": "^[0-9]{12}$"
+            }
+        },
+        "com.amazonaws.bedrockruntime#AdditionalModelResponseFieldPaths": {
+            "type": "list",
+            "member": {
+                "target": "smithy.api#String",
+                "traits": {
+                    "smithy.api#length": {
+                        "min": 1,
+                        "max": 256
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "max": 10
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#AmazonBedrockFrontendService": {
+            "type": "service",
+            "version": "2023-09-30",
+            "resources": [
+                {
+                    "target": "com.amazonaws.bedrockruntime#AsyncInvokeResource"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailResource"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#InferenceResource"
+                }
+            ],
+            "traits": {
+                "aws.api#service": {
+                    "sdkId": "Bedrock Runtime",
+                    "endpointPrefix": "bedrock-runtime",
+                    "cloudTrailEventSource": "bedrock.amazonaws.com"
+                },
+                "aws.auth#sigv4": {
+                    "name": "bedrock"
+                },
+                "aws.protocols#restJson1": {},
+                "smithy.api#documentation": "<p>Describes the API operations for running inference using Amazon Bedrock models.</p>",
+                "smithy.api#title": "Amazon Bedrock Runtime",
+                "smithy.rules#endpointRuleSet": {
+                    "version": "1.0",
+                    "parameters": {
+                        "Region": {
+                            "builtIn": "AWS::Region",
+                            "required": false,
+                            "documentation": "The AWS region used to dispatch the request.",
+                            "type": "String"
+                        },
+                        "UseDualStack": {
+                            "builtIn": "AWS::UseDualStack",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+                            "type": "Boolean"
+                        },
+                        "UseFIPS": {
+                            "builtIn": "AWS::UseFIPS",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+                            "type": "Boolean"
+                        },
+                        "Endpoint": {
+                            "builtIn": "SDK::Endpoint",
+                            "required": false,
+                            "documentation": "Override the endpoint used to send this request",
+                            "type": "String"
+                        }
+                    },
+                    "rules": [
+                        {
+                            "conditions": [
+                                {
+                                    "fn": "isSet",
+                                    "argv": [
+                                        {
+                                            "ref": "Endpoint"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "booleanEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "UseFIPS"
+                                                },
+                                                true
+                                            ]
+                                        }
+                                    ],
+                                    "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                                    "type": "error"
+                                },
+                                {
+                                    "conditions": [],
+                                    "rules": [
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        true
+                                                    ]
+                                                }
+                                            ],
+                                            "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                                            "type": "error"
+                                        },
+                                        {
+                                            "conditions": [],
+                                            "endpoint": {
+                                                "url": {
+                                                    "ref": "Endpoint"
+                                                },
+                                                "properties": {},
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        }
+                                    ],
+                                    "type": "tree"
+                                }
+                            ],
+                            "type": "tree"
+                        },
+                        {
+                            "conditions": [],
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "isSet",
+                                            "argv": [
+                                                {
+                                                    "ref": "Region"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "rules": [
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "aws.partition",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "Region"
+                                                        }
+                                                    ],
+                                                    "assign": "PartitionResult"
+                                                }
+                                            ],
+                                            "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseDualStack"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://bedrock-runtime-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree"
+                                                                }
+                                                            ],
+                                                            "type": "tree"
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                                                            "type": "error"
+                                                        }
+                                                    ],
+                                                    "type": "tree"
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://bedrock-runtime-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree"
+                                                                }
+                                                            ],
+                                                            "type": "tree"
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS is enabled but this partition does not support FIPS",
+                                                            "type": "error"
+                                                        }
+                                                    ],
+                                                    "type": "tree"
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseDualStack"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://bedrock-runtime.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree"
+                                                                }
+                                                            ],
+                                                            "type": "tree"
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "DualStack is enabled but this partition does not support DualStack",
+                                                            "type": "error"
+                                                        }
+                                                    ],
+                                                    "type": "tree"
+                                                },
+                                                {
+                                                    "conditions": [],
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [],
+                                                            "endpoint": {
+                                                                "url": "https://bedrock-runtime.{Region}.{PartitionResult#dnsSuffix}",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        }
+                                                    ],
+                                                    "type": "tree"
+                                                }
+                                            ],
+                                            "type": "tree"
+                                        }
+                                    ],
+                                    "type": "tree"
+                                },
+                                {
+                                    "conditions": [],
+                                    "error": "Invalid Configuration: Missing Region",
+                                    "type": "error"
+                                }
+                            ],
+                            "type": "tree"
+                        }
+                    ]
+                },
+                "smithy.rules#endpointTests": {
+                    "testCases": [
+                        {
+                            "documentation": "For region us-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://bedrock-runtime-fips.us-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://bedrock-runtime-fips.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://bedrock-runtime.us-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://bedrock-runtime.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://bedrock-runtime-fips.cn-north-1.api.amazonwebservices.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseFIPS": true,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://bedrock-runtime-fips.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://bedrock-runtime.cn-north-1.api.amazonwebservices.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://bedrock-runtime.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://bedrock-runtime-fips.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://bedrock-runtime-fips.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://bedrock-runtime.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://bedrock-runtime.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "error": "FIPS and DualStack are enabled, but this partition does not support one or both"
+                            },
+                            "params": {
+                                "Region": "us-iso-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://bedrock-runtime-fips.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-iso-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "error": "DualStack is enabled but this partition does not support DualStack"
+                            },
+                            "params": {
+                                "Region": "us-iso-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://bedrock-runtime.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-iso-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "error": "FIPS and DualStack are enabled, but this partition does not support one or both"
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://bedrock-runtime-fips.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "error": "DualStack is enabled but this partition does not support DualStack"
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://bedrock-runtime.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with fips enabled and dualstack disabled",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with fips disabled and dualstack enabled",
+                            "expect": {
+                                "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "Missing region",
+                            "expect": {
+                                "error": "Invalid Configuration: Missing Region"
+                            }
+                        }
+                    ],
+                    "version": "1.0"
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#AnyToolChoice": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#documentation": "<p>The model must request at least one tool (no text is generated). For example, <code>{\"any\" : {}}</code>.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#ApplyGuardrail": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.bedrockruntime#ApplyGuardrailRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.bedrockruntime#ApplyGuardrailResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.bedrockruntime#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>The action to apply a guardrail.</p>\n         <p>For troubleshooting some of the common errors you might encounter when using the <code>ApplyGuardrail</code> API, \n            see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/troubleshooting-api-error-codes.html\">Troubleshooting Amazon Bedrock API Error Codes</a> in the Amazon Bedrock User Guide</p>",
+                "smithy.api#http": {
+                    "code": 200,
+                    "method": "POST",
+                    "uri": "/guardrail/{guardrailIdentifier}/version/{guardrailVersion}/apply"
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#ApplyGuardrailRequest": {
+            "type": "structure",
+            "members": {
+                "guardrailIdentifier": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The guardrail identifier used in the request to apply the guardrail.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "guardrailVersion": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailVersion",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The guardrail version used in the request to apply the guardrail.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "source": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailContentSource",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The source of data used in the request to apply the guardrail.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "content": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailContentBlockList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The content details used in the request to apply the guardrail.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "outputScope": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailOutputScope",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the scope of the output that you get in the response. Set to <code>FULL</code> to return the entire output, including any detected and non-detected entries in the response for enhanced debugging.</p>\n         <p>Note that the full output scope doesn't apply to word filters or regex in sensitive information filters. It does apply to all other filtering policies, including sensitive information with filters that can detect personally identifiable information (PII).</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#ApplyGuardrailResponse": {
+            "type": "structure",
+            "members": {
+                "usage": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailUsage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The usage details in the response from the guardrail.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "action": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailAction",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The action taken in the response from the guardrail.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "actionReason": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The reason for the action taken when harmful content is detected.</p>"
+                    }
+                },
+                "outputs": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailOutputContentList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The output details in the response from the guardrail.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "assessments": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailAssessmentList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The assessment details in the response from the guardrail.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "guardrailCoverage": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailCoverage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The guardrail coverage details in the apply guardrail response.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#AsyncInvokeArn": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 2048
+                },
+                "smithy.api#pattern": "^arn:[a-z0-9\\-]+:bedrock:[a-z0-9\\-]*:[0-9]*:(provisioned-model|foundation-model)/.+$"
+            }
+        },
+        "com.amazonaws.bedrockruntime#AsyncInvokeIdempotencyToken": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 256
+                },
+                "smithy.api#pattern": "^[!-~]*$"
+            }
+        },
+        "com.amazonaws.bedrockruntime#AsyncInvokeIdentifier": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 256
+                },
+                "smithy.api#pattern": "^[a-zA-Z_\\.\\-/0-9:]+$"
+            }
+        },
+        "com.amazonaws.bedrockruntime#AsyncInvokeMessage": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "max": 2048
+                },
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#AsyncInvokeOutputDataConfig": {
+            "type": "union",
+            "members": {
+                "s3OutputDataConfig": {
+                    "target": "com.amazonaws.bedrockruntime#AsyncInvokeS3OutputDataConfig",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A storage location for the output data in an S3 bucket</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Asynchronous invocation output data settings.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#AsyncInvokeResource": {
+            "type": "resource",
+            "operations": [
+                {
+                    "target": "com.amazonaws.bedrockruntime#GetAsyncInvoke"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ListAsyncInvokes"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#StartAsyncInvoke"
+                }
+            ]
+        },
+        "com.amazonaws.bedrockruntime#AsyncInvokeS3OutputDataConfig": {
+            "type": "structure",
+            "members": {
+                "s3Uri": {
+                    "target": "com.amazonaws.bedrockruntime#S3Uri",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An object URI starting with <code>s3://</code>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "kmsKeyId": {
+                    "target": "com.amazonaws.bedrockruntime#KmsKeyId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A KMS encryption key ID.</p>"
+                    }
+                },
+                "bucketOwner": {
+                    "target": "com.amazonaws.bedrockruntime#AccountId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the bucket belongs to another AWS account, specify that account's ID.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Asynchronous invocation output data settings.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#AsyncInvokeStatus": {
+            "type": "enum",
+            "members": {
+                "IN_PROGRESS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "InProgress"
+                    }
+                },
+                "COMPLETED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Completed"
+                    }
+                },
+                "FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Failed"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#AsyncInvokeSummaries": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.bedrockruntime#AsyncInvokeSummary"
+            }
+        },
+        "com.amazonaws.bedrockruntime#AsyncInvokeSummary": {
+            "type": "structure",
+            "members": {
+                "invocationArn": {
+                    "target": "com.amazonaws.bedrockruntime#InvocationArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The invocation's ARN.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "modelArn": {
+                    "target": "com.amazonaws.bedrockruntime#AsyncInvokeArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The invoked model's ARN.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "clientRequestToken": {
+                    "target": "com.amazonaws.bedrockruntime#AsyncInvokeIdempotencyToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The invocation's idempotency token.</p>"
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.bedrockruntime#AsyncInvokeStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The invocation's status.</p>"
+                    }
+                },
+                "failureMessage": {
+                    "target": "com.amazonaws.bedrockruntime#AsyncInvokeMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An error message.</p>"
+                    }
+                },
+                "submitTime": {
+                    "target": "com.amazonaws.bedrockruntime#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>When the invocation was submitted.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "lastModifiedTime": {
+                    "target": "com.amazonaws.bedrockruntime#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>When the invocation was last modified.</p>"
+                    }
+                },
+                "endTime": {
+                    "target": "com.amazonaws.bedrockruntime#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>When the invocation ended.</p>"
+                    }
+                },
+                "outputDataConfig": {
+                    "target": "com.amazonaws.bedrockruntime#AsyncInvokeOutputDataConfig",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The invocation's output data settings.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A summary of an asynchronous invocation.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#AutoToolChoice": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#documentation": "<p>The Model automatically decides if a tool should be called or whether to generate text instead.\n         For example, <code>{\"auto\" : {}}</code>.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#BidirectionalInputPayloadPart": {
+            "type": "structure",
+            "members": {
+                "bytes": {
+                    "target": "com.amazonaws.bedrockruntime#PartBody",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The audio content for the bidirectional input.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Payload content for the bidirectional input. The input is an audio stream.</p>",
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#BidirectionalOutputPayloadPart": {
+            "type": "structure",
+            "members": {
+                "bytes": {
+                    "target": "com.amazonaws.bedrockruntime#PartBody",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The speech output of the bidirectional stream.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Output from the bidirectional stream. The output is speech and a text transcription.</p>",
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#Body": {
+            "type": "blob",
+            "traits": {
+                "smithy.api#length": {
+                    "max": 25000000
+                },
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#CachePointBlock": {
+            "type": "structure",
+            "members": {
+                "type": {
+                    "target": "com.amazonaws.bedrockruntime#CachePointType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the type of cache point within the CachePointBlock.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Defines a section of content to be cached for reuse in subsequent API calls.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#CachePointType": {
+            "type": "enum",
+            "members": {
+                "DEFAULT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "default"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#ConflictException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.bedrockruntime#NonBlankString"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Error occurred because of a conflict while performing an operation.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.bedrockruntime#ContentBlock": {
+            "type": "union",
+            "members": {
+                "text": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Text to include in the message.</p>"
+                    }
+                },
+                "image": {
+                    "target": "com.amazonaws.bedrockruntime#ImageBlock",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Image to include in the message. </p>\n         <note>\n            <p>This field is only supported by Anthropic Claude 3 models.</p>\n         </note>"
+                    }
+                },
+                "document": {
+                    "target": "com.amazonaws.bedrockruntime#DocumentBlock",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A document to include in the message.</p>"
+                    }
+                },
+                "video": {
+                    "target": "com.amazonaws.bedrockruntime#VideoBlock",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Video to include in the message. </p>"
+                    }
+                },
+                "toolUse": {
+                    "target": "com.amazonaws.bedrockruntime#ToolUseBlock",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about a tool use request from a model.</p>"
+                    }
+                },
+                "toolResult": {
+                    "target": "com.amazonaws.bedrockruntime#ToolResultBlock",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The result for a tool request that a model makes.</p>"
+                    }
+                },
+                "guardContent": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailConverseContentBlock",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Contains the content to assess with the guardrail. If you don't specify\n            <code>guardContent</code> in a call to the Converse API, the guardrail (if passed in the\n         Converse API) assesses the entire message.</p>\n         <p>For more information, see  <i>Use a guardrail with the Converse API</i> in the <i>Amazon Bedrock User Guide</i>.\n\n      </p>"
+                    }
+                },
+                "cachePoint": {
+                    "target": "com.amazonaws.bedrockruntime#CachePointBlock",
+                    "traits": {
+                        "smithy.api#documentation": "<p>CachePoint to include in the message.</p>"
+                    }
+                },
+                "reasoningContent": {
+                    "target": "com.amazonaws.bedrockruntime#ReasoningContentBlock",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Contains content regarding the reasoning that is carried out by the model. Reasoning refers to a Chain of Thought (CoT) that the model generates to enhance the accuracy of its final response.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A block of content for a message that you pass to, or receive from, a model with the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html\">Converse</a> or <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ConverseStream.html\">ConverseStream</a> API operations.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#ContentBlockDelta": {
+            "type": "union",
+            "members": {
+                "text": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The content text.</p>"
+                    }
+                },
+                "toolUse": {
+                    "target": "com.amazonaws.bedrockruntime#ToolUseBlockDelta",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about a tool that the model is requesting to use.</p>"
+                    }
+                },
+                "reasoningContent": {
+                    "target": "com.amazonaws.bedrockruntime#ReasoningContentBlockDelta",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Contains content regarding the reasoning that is carried out by the model. Reasoning refers to a Chain of Thought (CoT) that the model generates to enhance the accuracy of its final response.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A block of content in a streaming response.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#ContentBlockDeltaEvent": {
+            "type": "structure",
+            "members": {
+                "delta": {
+                    "target": "com.amazonaws.bedrockruntime#ContentBlockDelta",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The delta for a content block delta event.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "contentBlockIndex": {
+                    "target": "com.amazonaws.bedrockruntime#NonNegativeInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The block index for a content block delta event. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The content block delta event.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#ContentBlockStart": {
+            "type": "union",
+            "members": {
+                "toolUse": {
+                    "target": "com.amazonaws.bedrockruntime#ToolUseBlockStart",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about a tool that the model is requesting to use.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Content block start information.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#ContentBlockStartEvent": {
+            "type": "structure",
+            "members": {
+                "start": {
+                    "target": "com.amazonaws.bedrockruntime#ContentBlockStart",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Start information about a content block start event.  </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "contentBlockIndex": {
+                    "target": "com.amazonaws.bedrockruntime#NonNegativeInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The index for a content block start event.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Content block start event.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#ContentBlockStopEvent": {
+            "type": "structure",
+            "members": {
+                "contentBlockIndex": {
+                    "target": "com.amazonaws.bedrockruntime#NonNegativeInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The index for a content block.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A content block stop event.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#ContentBlocks": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.bedrockruntime#ContentBlock"
+            }
+        },
+        "com.amazonaws.bedrockruntime#ConversationRole": {
+            "type": "enum",
+            "members": {
+                "USER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "user"
+                    }
+                },
+                "ASSISTANT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "assistant"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#ConversationalModelId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 2048
+                },
+                "smithy.api#pattern": "^(arn:aws(-[^:]+)?:bedrock:[a-z0-9-]{1,20}:(([0-9]{12}:custom-model/[a-z0-9-]{1,63}[.]{1}[a-z0-9-]{1,63}/[a-z0-9]{12})|(:foundation-model/[a-z0-9-]{1,63}[.]{1}[a-z0-9-]{1,63}([.:]?[a-z0-9-]{1,63}))|([0-9]{12}:imported-model/[a-z0-9]{12})|([0-9]{12}:provisioned-model/[a-z0-9]{12})|([0-9]{12}:(inference-profile|application-inference-profile)/[a-zA-Z0-9-:.]+)))|([a-z0-9-]{1,63}[.]{1}[a-z0-9-]{1,63}([.:]?[a-z0-9-]{1,63}))|(([0-9a-zA-Z][_-]?)+)|([a-zA-Z0-9-:.]+)|(^(arn:aws(-[^:]+)?:bedrock:[a-z0-9-]{1,20}:[0-9]{12}:prompt/[0-9a-zA-Z]{10}(?::[0-9]{1,5})?))$|(^arn:aws:sagemaker:[a-z0-9-]+:[0-9]{12}:endpoint/[a-zA-Z0-9-]+$)|(^arn:aws(-[^:]+)?:bedrock:([0-9a-z-]{1,20}):([0-9]{12}):(default-)?prompt-router/[a-zA-Z0-9-:.]+$)$"
+            }
+        },
+        "com.amazonaws.bedrockruntime#Converse": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.bedrockruntime#ConverseRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.bedrockruntime#ConverseResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.bedrockruntime#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ModelErrorException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ModelNotReadyException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ModelTimeoutException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ServiceUnavailableException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Sends messages to the specified Amazon Bedrock model. <code>Converse</code> provides\n         a consistent interface that works with all models that\n         support messages. This allows you to write code once and use it with different models.\n         If a model has unique inference parameters, you can also pass those unique parameters\n         to the model.</p>\n         <p>Amazon Bedrock doesn't store any text, images, or documents that you provide as content. The data is only used to generate the response.</p>\n         <p>You can submit a prompt by including it in the <code>messages</code> field, specifying the <code>modelId</code> of a foundation model or inference profile to run inference on it, and including any other fields that are relevant to your use case.</p>\n         <p>You can also submit a prompt from Prompt management by specifying the ARN of the prompt version and including a map of variables to values in the <code>promptVariables</code> field. You can append more messages to the prompt by using the <code>messages</code> field. If you use a prompt from Prompt management, you can't include the following fields in the request: <code>additionalModelRequestFields</code>, <code>inferenceConfig</code>, <code>system</code>, or <code>toolConfig</code>. Instead, these fields must be defined through Prompt management. For more information, see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-management-use.html\">Use a prompt from Prompt management</a>.</p>\n         <p>For information about the Converse API, see <i>Use the Converse API</i> in the <i>Amazon Bedrock User Guide</i>.\n            To use a guardrail, see  <i>Use a guardrail with the Converse API</i> in the <i>Amazon Bedrock User Guide</i>.\n            To use a tool with a model, see <i>Tool use (Function calling)</i> in the <i>Amazon Bedrock User Guide</i>\n         </p>\n         <p>For example code, see <i>Converse API examples</i> in the <i>Amazon Bedrock User Guide</i>.\n      </p>\n         <p>This operation requires permission for the <code>bedrock:InvokeModel</code> action. </p>\n         <important>\n            <p>To deny all inference access to resources that you specify in the modelId field, you\n         need to deny access to the <code>bedrock:InvokeModel</code> and\n         <code>bedrock:InvokeModelWithResponseStream</code> actions. Doing this also denies\n         access to the resource through the base inference actions (<a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InvokeModel.html\">InvokeModel</a> and <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InvokeModelWithResponseStream.html\">InvokeModelWithResponseStream</a>). For more information see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/security_iam_id-based-policy-examples.html#security_iam_id-based-policy-examples-deny-inference\">Deny access for inference on specific models</a>.\n      </p>\n         </important>\n         <p>For troubleshooting some of the common errors you might encounter when using the <code>Converse</code> API, \n         see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/troubleshooting-api-error-codes.html\">Troubleshooting Amazon Bedrock API Error Codes</a> in the Amazon Bedrock User Guide</p>",
+                "smithy.api#http": {
+                    "code": 200,
+                    "method": "POST",
+                    "uri": "/model/{modelId}/converse"
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#ConverseMetrics": {
+            "type": "structure",
+            "members": {
+                "latencyMs": {
+                    "target": "smithy.api#Long",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The latency of the call to <code>Converse</code>, in milliseconds.\n         </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Metrics for a call to <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html\">Converse</a>.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#ConverseOutput": {
+            "type": "union",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.bedrockruntime#Message",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The message that the model generates.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The output from a call to <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html\">Converse</a>.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#ConverseRequest": {
+            "type": "structure",
+            "members": {
+                "modelId": {
+                    "target": "com.amazonaws.bedrockruntime#ConversationalModelId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the model or throughput with which to run inference, or the prompt resource to use in inference. The value depends on the resource that you use:</p>\n         <ul>\n            <li>\n               <p>If you use a base model, specify the model ID or its ARN. For a list of model IDs for base models, see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html#model-ids-arns\">Amazon Bedrock base model IDs (on-demand throughput)</a> in the Amazon Bedrock User Guide.</p>\n            </li>\n            <li>\n               <p>If you use an inference profile, specify the inference profile ID or its ARN. For a list of inference profile IDs, see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html\">Supported Regions and models for cross-region inference</a> in the Amazon Bedrock User Guide.</p>\n            </li>\n            <li>\n               <p>If you use a provisioned model, specify the ARN of the Provisioned Throughput. For more information, see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/prov-thru-use.html\">Run inference using a Provisioned Throughput</a> in the Amazon Bedrock User Guide.</p>\n            </li>\n            <li>\n               <p>If you use a custom model, first purchase Provisioned Throughput for it. Then specify the ARN of the resulting provisioned model. For more information, see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-use.html\">Use a custom model in Amazon Bedrock</a> in the Amazon Bedrock User Guide.</p>\n            </li>\n            <li>\n               <p>To include a prompt that was defined in <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-management.html\">Prompt management</a>, specify the ARN of the prompt version to use.</p>\n            </li>\n         </ul>\n         <p>The Converse API doesn't support <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-import-model.html\">imported models</a>.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "messages": {
+                    "target": "com.amazonaws.bedrockruntime#Messages",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The messages that you want to send to the model.</p>"
+                    }
+                },
+                "system": {
+                    "target": "com.amazonaws.bedrockruntime#SystemContentBlocks",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A prompt that provides instructions or context to the model about the task it should perform, or the persona it should adopt during the conversation.</p>"
+                    }
+                },
+                "inferenceConfig": {
+                    "target": "com.amazonaws.bedrockruntime#InferenceConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Inference parameters to pass to the model. <code>Converse</code> and <code>ConverseStream</code> support a base\n         set of inference parameters. If you need to pass additional parameters that the model\n         supports, use the <code>additionalModelRequestFields</code> request field.</p>"
+                    }
+                },
+                "toolConfig": {
+                    "target": "com.amazonaws.bedrockruntime#ToolConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configuration information for the tools that the model can use when generating a response. </p>\n         <p>For information about models that support tool use, see \n         <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html#conversation-inference-supported-models-features\">Supported models and model features</a>.</p>"
+                    }
+                },
+                "guardrailConfig": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configuration information for a guardrail that you want to use in the request. If you include <code>guardContent</code> blocks in the <code>content</code> field in the <code>messages</code> field, the guardrail operates only on those messages. If you include no <code>guardContent</code> blocks, the guardrail operates on all messages in the request body and in any included prompt resource.</p>"
+                    }
+                },
+                "additionalModelRequestFields": {
+                    "target": "smithy.api#Document",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Additional inference parameters that the model supports, beyond the\n         base set of inference parameters that <code>Converse</code> and <code>ConverseStream</code> support in the <code>inferenceConfig</code>\n         field. For more information, see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html\">Model parameters</a>.</p>"
+                    }
+                },
+                "promptVariables": {
+                    "target": "com.amazonaws.bedrockruntime#PromptVariableMap",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Contains a map of variables in a prompt from Prompt management to objects containing the values to fill in for them when running model invocation. This field is ignored if you don't specify a prompt resource in the <code>modelId</code> field.</p>"
+                    }
+                },
+                "additionalModelResponseFieldPaths": {
+                    "target": "com.amazonaws.bedrockruntime#AdditionalModelResponseFieldPaths",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Additional model parameters field paths to return in the\n         response. <code>Converse</code> and <code>ConverseStream</code> return the requested fields as a JSON Pointer object in the\n         <code>additionalModelResponseFields</code> field. The following is example JSON for <code>additionalModelResponseFieldPaths</code>.</p>\n         <p>\n            <code>[\n         \"/stop_sequence\"\n         ]</code>\n         </p>\n         <p>For information about the JSON Pointer syntax, see the\n         <a href=\"https://datatracker.ietf.org/doc/html/rfc6901\">Internet Engineering Task Force (IETF)</a> documentation.</p>\n         <p>\n            <code>Converse</code> and <code>ConverseStream</code> reject an empty JSON Pointer or incorrectly structured\n         JSON Pointer with a <code>400</code> error code. if the JSON Pointer is valid, but the requested\n         field is not in the model response, it is ignored by <code>Converse</code>.</p>",
+                        "smithy.api#length": {
+                            "max": 10
+                        }
+                    }
+                },
+                "requestMetadata": {
+                    "target": "com.amazonaws.bedrockruntime#RequestMetadata",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Key-value pairs that you can use to filter invocation logs.</p>"
+                    }
+                },
+                "performanceConfig": {
+                    "target": "com.amazonaws.bedrockruntime#PerformanceConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Model performance settings for the request.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#ConverseResponse": {
+            "type": "structure",
+            "members": {
+                "output": {
+                    "target": "com.amazonaws.bedrockruntime#ConverseOutput",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The result from the call to <code>Converse</code>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "stopReason": {
+                    "target": "com.amazonaws.bedrockruntime#StopReason",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The reason why the model stopped generating output.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "usage": {
+                    "target": "com.amazonaws.bedrockruntime#TokenUsage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The total number of tokens used in the call to <code>Converse</code>. The total includes\n         the tokens input to the model and the tokens generated by the model.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "metrics": {
+                    "target": "com.amazonaws.bedrockruntime#ConverseMetrics",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Metrics for the call to <code>Converse</code>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "additionalModelResponseFields": {
+                    "target": "smithy.api#Document",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Additional fields in the response that are unique to the model. </p>"
+                    }
+                },
+                "trace": {
+                    "target": "com.amazonaws.bedrockruntime#ConverseTrace",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A trace object that contains information about the Guardrail behavior.</p>"
+                    }
+                },
+                "performanceConfig": {
+                    "target": "com.amazonaws.bedrockruntime#PerformanceConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Model performance settings for the request.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#ConverseStream": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.bedrockruntime#ConverseStreamRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.bedrockruntime#ConverseStreamResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.bedrockruntime#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ModelErrorException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ModelNotReadyException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ModelTimeoutException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ServiceUnavailableException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Sends messages to the specified Amazon Bedrock model and returns\n         the response in a stream. <code>ConverseStream</code> provides a consistent API\n         that works with all Amazon Bedrock models that support messages.\n         This allows you to write code once and use it with different models. Should a\n         model have unique inference parameters, you can also pass those unique parameters to the\n         model. </p>\n         <p>To find out if a model supports streaming, call <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_GetFoundationModel.html\">GetFoundationModel</a>\n         and check the <code>responseStreamingSupported</code> field in the response.</p>\n         <note>\n            <p>The CLI doesn't support streaming operations in Amazon Bedrock, including <code>ConverseStream</code>.</p>\n         </note>\n         <p>Amazon Bedrock doesn't store any text, images, or documents that you provide as content. The data is only used to generate the response.</p>\n         <p>You can submit a prompt by including it in the <code>messages</code> field, specifying the <code>modelId</code> of a foundation model or inference profile to run inference on it, and including any other fields that are relevant to your use case.</p>\n         <p>You can also submit a prompt from Prompt management by specifying the ARN of the prompt version and including a map of variables to values in the <code>promptVariables</code> field. You can append more messages to the prompt by using the <code>messages</code> field. If you use a prompt from Prompt management, you can't include the following fields in the request: <code>additionalModelRequestFields</code>, <code>inferenceConfig</code>, <code>system</code>, or <code>toolConfig</code>. Instead, these fields must be defined through Prompt management. For more information, see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-management-use.html\">Use a prompt from Prompt management</a>.</p>\n         <p>For information about the Converse API, see <i>Use the Converse API</i> in the <i>Amazon Bedrock User Guide</i>.\n         To use a guardrail, see  <i>Use a guardrail with the Converse API</i> in the <i>Amazon Bedrock User Guide</i>.\n         To use a tool with a model, see <i>Tool use (Function calling)</i> in the <i>Amazon Bedrock User Guide</i>\n         </p>\n         <p>For example code, see <i>Conversation streaming example</i> in the <i>Amazon Bedrock User Guide</i>.\n      </p>\n         <p>This operation requires permission for the <code>bedrock:InvokeModelWithResponseStream</code> action.</p>\n         <important>\n            <p>To deny all inference access to resources that you specify in the modelId field, you\n         need to deny access to the <code>bedrock:InvokeModel</code> and\n         <code>bedrock:InvokeModelWithResponseStream</code> actions. Doing this also denies\n         access to the resource through the base inference actions (<a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InvokeModel.html\">InvokeModel</a> and <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InvokeModelWithResponseStream.html\">InvokeModelWithResponseStream</a>). For more information see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/security_iam_id-based-policy-examples.html#security_iam_id-based-policy-examples-deny-inference\">Deny access for inference on specific models</a>.\n      </p>\n         </important>\n         <p>For troubleshooting some of the common errors you might encounter when using the <code>ConverseStream</code> API, \n         see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/troubleshooting-api-error-codes.html\">Troubleshooting Amazon Bedrock API Error Codes</a> in the Amazon Bedrock User Guide</p>",
+                "smithy.api#http": {
+                    "code": 200,
+                    "method": "POST",
+                    "uri": "/model/{modelId}/converse-stream"
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#ConverseStreamMetadataEvent": {
+            "type": "structure",
+            "members": {
+                "usage": {
+                    "target": "com.amazonaws.bedrockruntime#TokenUsage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Usage information for the conversation stream event.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "metrics": {
+                    "target": "com.amazonaws.bedrockruntime#ConverseStreamMetrics",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The metrics for the conversation stream metadata event.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "trace": {
+                    "target": "com.amazonaws.bedrockruntime#ConverseStreamTrace",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The trace object in the response from <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ConverseStream.html\">ConverseStream</a> that contains information about the guardrail behavior.</p>"
+                    }
+                },
+                "performanceConfig": {
+                    "target": "com.amazonaws.bedrockruntime#PerformanceConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Model performance configuration metadata for the conversation stream event.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A conversation stream metadata event.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#ConverseStreamMetrics": {
+            "type": "structure",
+            "members": {
+                "latencyMs": {
+                    "target": "smithy.api#Long",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The latency for the streaming request, in milliseconds.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Metrics for the stream.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#ConverseStreamOutput": {
+            "type": "union",
+            "members": {
+                "messageStart": {
+                    "target": "com.amazonaws.bedrockruntime#MessageStartEvent",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Message start information.</p>"
+                    }
+                },
+                "contentBlockStart": {
+                    "target": "com.amazonaws.bedrockruntime#ContentBlockStartEvent",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Start information for a content block.</p>"
+                    }
+                },
+                "contentBlockDelta": {
+                    "target": "com.amazonaws.bedrockruntime#ContentBlockDeltaEvent",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The messages output content block delta.</p>"
+                    }
+                },
+                "contentBlockStop": {
+                    "target": "com.amazonaws.bedrockruntime#ContentBlockStopEvent",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Stop information for a content block.</p>"
+                    }
+                },
+                "messageStop": {
+                    "target": "com.amazonaws.bedrockruntime#MessageStopEvent",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Message stop information.</p>"
+                    }
+                },
+                "metadata": {
+                    "target": "com.amazonaws.bedrockruntime#ConverseStreamMetadataEvent",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Metadata for the converse output stream.</p>"
+                    }
+                },
+                "internalServerException": {
+                    "target": "com.amazonaws.bedrockruntime#InternalServerException",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An internal server error occurred. Retry your request.</p>"
+                    }
+                },
+                "modelStreamErrorException": {
+                    "target": "com.amazonaws.bedrockruntime#ModelStreamErrorException",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A streaming error occurred. Retry your request.</p>"
+                    }
+                },
+                "validationException": {
+                    "target": "com.amazonaws.bedrockruntime#ValidationException",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The input fails to satisfy the constraints specified by <i>Amazon Bedrock</i>. For troubleshooting this error, \n         see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/troubleshooting-api-error-codes.html#ts-validation-error\">ValidationError</a> in the Amazon Bedrock User Guide</p>"
+                    }
+                },
+                "throttlingException": {
+                    "target": "com.amazonaws.bedrockruntime#ThrottlingException",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Your request was denied due to exceeding the account quotas for <i>Amazon Bedrock</i>. For\n         troubleshooting this error, see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/troubleshooting-api-error-codes.html#ts-throttling-exception\">ThrottlingException</a> in the Amazon Bedrock User Guide</p>"
+                    }
+                },
+                "serviceUnavailableException": {
+                    "target": "com.amazonaws.bedrockruntime#ServiceUnavailableException",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The service isn't currently available. For troubleshooting this error, \n         see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/troubleshooting-api-error-codes.html#ts-service-unavailable\">ServiceUnavailable</a> in the Amazon Bedrock User Guide</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The messages output stream</p>",
+                "smithy.api#streaming": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#ConverseStreamRequest": {
+            "type": "structure",
+            "members": {
+                "modelId": {
+                    "target": "com.amazonaws.bedrockruntime#ConversationalModelId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the model or throughput with which to run inference, or the prompt resource to use in inference. The value depends on the resource that you use:</p>\n         <ul>\n            <li>\n               <p>If you use a base model, specify the model ID or its ARN. For a list of model IDs for base models, see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html#model-ids-arns\">Amazon Bedrock base model IDs (on-demand throughput)</a> in the Amazon Bedrock User Guide.</p>\n            </li>\n            <li>\n               <p>If you use an inference profile, specify the inference profile ID or its ARN. For a list of inference profile IDs, see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html\">Supported Regions and models for cross-region inference</a> in the Amazon Bedrock User Guide.</p>\n            </li>\n            <li>\n               <p>If you use a provisioned model, specify the ARN of the Provisioned Throughput. For more information, see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/prov-thru-use.html\">Run inference using a Provisioned Throughput</a> in the Amazon Bedrock User Guide.</p>\n            </li>\n            <li>\n               <p>If you use a custom model, first purchase Provisioned Throughput for it. Then specify the ARN of the resulting provisioned model. For more information, see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-use.html\">Use a custom model in Amazon Bedrock</a> in the Amazon Bedrock User Guide.</p>\n            </li>\n            <li>\n               <p>To include a prompt that was defined in <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-management.html\">Prompt management</a>, specify the ARN of the prompt version to use.</p>\n            </li>\n         </ul>\n         <p>The Converse API doesn't support <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-import-model.html\">imported models</a>.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "messages": {
+                    "target": "com.amazonaws.bedrockruntime#Messages",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The messages that you want to send to the model.</p>"
+                    }
+                },
+                "system": {
+                    "target": "com.amazonaws.bedrockruntime#SystemContentBlocks",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A prompt that provides instructions or context to the model about the task it should perform, or the persona it should adopt during the conversation.</p>"
+                    }
+                },
+                "inferenceConfig": {
+                    "target": "com.amazonaws.bedrockruntime#InferenceConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Inference parameters to pass to the model. <code>Converse</code> and <code>ConverseStream</code> support a base\n         set of inference parameters. If you need to pass additional parameters that the model\n         supports, use the <code>additionalModelRequestFields</code> request field.</p>"
+                    }
+                },
+                "toolConfig": {
+                    "target": "com.amazonaws.bedrockruntime#ToolConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configuration information for the tools that the model can use when generating a response.</p>\n         <p>For information about models that support streaming tool use, see \n            <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html#conversation-inference-supported-models-features\">Supported models and model features</a>.</p>"
+                    }
+                },
+                "guardrailConfig": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailStreamConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configuration information for a guardrail that you want to use in the request. If you include <code>guardContent</code> blocks in the <code>content</code> field in the <code>messages</code> field, the guardrail operates only on those messages. If you include no <code>guardContent</code> blocks, the guardrail operates on all messages in the request body and in any included prompt resource.</p>"
+                    }
+                },
+                "additionalModelRequestFields": {
+                    "target": "smithy.api#Document",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Additional inference parameters that the model supports, beyond the\n         base set of inference parameters that <code>Converse</code> and <code>ConverseStream</code> support in the <code>inferenceConfig</code>\n         field. For more information, see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html\">Model parameters</a>.</p>"
+                    }
+                },
+                "promptVariables": {
+                    "target": "com.amazonaws.bedrockruntime#PromptVariableMap",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Contains a map of variables in a prompt from Prompt management to objects containing the values to fill in for them when running model invocation. This field is ignored if you don't specify a prompt resource in the <code>modelId</code> field.</p>"
+                    }
+                },
+                "additionalModelResponseFieldPaths": {
+                    "target": "com.amazonaws.bedrockruntime#AdditionalModelResponseFieldPaths",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Additional model parameters field paths to return in the\n         response. <code>Converse</code> and <code>ConverseStream</code> return the requested fields as a JSON Pointer object in the\n         <code>additionalModelResponseFields</code> field. The following is example JSON for <code>additionalModelResponseFieldPaths</code>.</p>\n         <p>\n            <code>[\n         \"/stop_sequence\"\n         ]</code>\n         </p>\n         <p>For information about the JSON Pointer syntax, see the\n         <a href=\"https://datatracker.ietf.org/doc/html/rfc6901\">Internet Engineering Task Force (IETF)</a> documentation.</p>\n         <p>\n            <code>Converse</code> and <code>ConverseStream</code> reject an empty JSON Pointer or incorrectly structured\n         JSON Pointer with a <code>400</code> error code. if the JSON Pointer is valid, but the requested\n         field is not in the model response, it is ignored by <code>Converse</code>.</p>",
+                        "smithy.api#length": {
+                            "max": 10
+                        }
+                    }
+                },
+                "requestMetadata": {
+                    "target": "com.amazonaws.bedrockruntime#RequestMetadata",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Key-value pairs that you can use to filter invocation logs.</p>"
+                    }
+                },
+                "performanceConfig": {
+                    "target": "com.amazonaws.bedrockruntime#PerformanceConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Model performance settings for the request.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#ConverseStreamResponse": {
+            "type": "structure",
+            "members": {
+                "stream": {
+                    "target": "com.amazonaws.bedrockruntime#ConverseStreamOutput",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The output stream that the model generated.</p>",
+                        "smithy.api#httpPayload": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#ConverseStreamTrace": {
+            "type": "structure",
+            "members": {
+                "guardrail": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailTraceAssessment",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The guardrail trace object. </p>"
+                    }
+                },
+                "promptRouter": {
+                    "target": "com.amazonaws.bedrockruntime#PromptRouterTrace",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The request's prompt router.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The trace object in a response from <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ConverseStream.html\">ConverseStream</a>. Currently, you can only trace guardrails.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#ConverseTrace": {
+            "type": "structure",
+            "members": {
+                "guardrail": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailTraceAssessment",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The guardrail trace object. </p>"
+                    }
+                },
+                "promptRouter": {
+                    "target": "com.amazonaws.bedrockruntime#PromptRouterTrace",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The request's prompt router.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The trace object in a response from <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html\">Converse</a>. Currently, you can only trace guardrails.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#DocumentBlock": {
+            "type": "structure",
+            "members": {
+                "format": {
+                    "target": "com.amazonaws.bedrockruntime#DocumentFormat",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The format of a document, or its extension.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "name": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A name for the document. The name can only contain the following characters:</p>\n         <ul>\n            <li>\n               <p>Alphanumeric characters</p>\n            </li>\n            <li>\n               <p>Whitespace characters (no more than one in a row)</p>\n            </li>\n            <li>\n               <p>Hyphens</p>\n            </li>\n            <li>\n               <p>Parentheses</p>\n            </li>\n            <li>\n               <p>Square brackets</p>\n            </li>\n         </ul>\n         <note>\n            <p>This field is vulnerable to prompt injections, because the model might inadvertently interpret it as instructions. Therefore, we recommend that you specify a neutral name.</p>\n         </note>",
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 200
+                        },
+                        "smithy.api#required": {}
+                    }
+                },
+                "source": {
+                    "target": "com.amazonaws.bedrockruntime#DocumentSource",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Contains the content of the document.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A document to include in a message.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#DocumentFormat": {
+            "type": "enum",
+            "members": {
+                "PDF": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "pdf"
+                    }
+                },
+                "CSV": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "csv"
+                    }
+                },
+                "DOC": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "doc"
+                    }
+                },
+                "DOCX": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "docx"
+                    }
+                },
+                "XLS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "xls"
+                    }
+                },
+                "XLSX": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "xlsx"
+                    }
+                },
+                "HTML": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "html"
+                    }
+                },
+                "TXT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "txt"
+                    }
+                },
+                "MD": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "md"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#DocumentSource": {
+            "type": "union",
+            "members": {
+                "bytes": {
+                    "target": "smithy.api#Blob",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The raw bytes for the document. If you use an Amazon Web Services SDK, you don't need to encode the bytes in base64.</p>",
+                        "smithy.api#length": {
+                            "min": 1
+                        }
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains the content of a document.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GetAsyncInvoke": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.bedrockruntime#GetAsyncInvokeRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.bedrockruntime#GetAsyncInvokeResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.bedrockruntime#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Retrieve information about an asynchronous invocation.</p>",
+                "smithy.api#http": {
+                    "code": 200,
+                    "method": "GET",
+                    "uri": "/async-invoke/{invocationArn}"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#GetAsyncInvokeRequest": {
+            "type": "structure",
+            "members": {
+                "invocationArn": {
+                    "target": "com.amazonaws.bedrockruntime#InvocationArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The invocation's ARN.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#GetAsyncInvokeResponse": {
+            "type": "structure",
+            "members": {
+                "invocationArn": {
+                    "target": "com.amazonaws.bedrockruntime#InvocationArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The invocation's ARN.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "modelArn": {
+                    "target": "com.amazonaws.bedrockruntime#AsyncInvokeArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The invocation's model ARN.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "clientRequestToken": {
+                    "target": "com.amazonaws.bedrockruntime#AsyncInvokeIdempotencyToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The invocation's idempotency token.</p>"
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.bedrockruntime#AsyncInvokeStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The invocation's status.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "failureMessage": {
+                    "target": "com.amazonaws.bedrockruntime#AsyncInvokeMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An error message.</p>"
+                    }
+                },
+                "submitTime": {
+                    "target": "com.amazonaws.bedrockruntime#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>When the invocation request was submitted.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "lastModifiedTime": {
+                    "target": "com.amazonaws.bedrockruntime#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The invocation's last modified time.</p>"
+                    }
+                },
+                "endTime": {
+                    "target": "com.amazonaws.bedrockruntime#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>When the invocation ended.</p>"
+                    }
+                },
+                "outputDataConfig": {
+                    "target": "com.amazonaws.bedrockruntime#AsyncInvokeOutputDataConfig",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Output data settings.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailAction": {
+            "type": "enum",
+            "members": {
+                "NONE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NONE"
+                    }
+                },
+                "GUARDRAIL_INTERVENED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "GUARDRAIL_INTERVENED"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailAssessment": {
+            "type": "structure",
+            "members": {
+                "topicPolicy": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailTopicPolicyAssessment",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The topic policy.</p>"
+                    }
+                },
+                "contentPolicy": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailContentPolicyAssessment",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The content policy.</p>"
+                    }
+                },
+                "wordPolicy": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailWordPolicyAssessment",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The word policy.</p>"
+                    }
+                },
+                "sensitiveInformationPolicy": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailSensitiveInformationPolicyAssessment",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The sensitive information policy.</p>"
+                    }
+                },
+                "contextualGroundingPolicy": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailContextualGroundingPolicyAssessment",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The contextual grounding policy used for the guardrail assessment.</p>"
+                    }
+                },
+                "invocationMetrics": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailInvocationMetrics",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The invocation metrics for the guardrail assessment.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A behavior assessment of the guardrail policies used in a call to the Converse API. </p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailAssessmentList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.bedrockruntime#GuardrailAssessment"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailAssessmentListMap": {
+            "type": "map",
+            "key": {
+                "target": "smithy.api#String"
+            },
+            "value": {
+                "target": "com.amazonaws.bedrockruntime#GuardrailAssessmentList"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailAssessmentMap": {
+            "type": "map",
+            "key": {
+                "target": "smithy.api#String"
+            },
+            "value": {
+                "target": "com.amazonaws.bedrockruntime#GuardrailAssessment"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailConfiguration": {
+            "type": "structure",
+            "members": {
+                "guardrailIdentifier": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier for the guardrail.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "guardrailVersion": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailVersion",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the guardrail.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "trace": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailTrace",
+                    "traits": {
+                        "smithy.api#default": "disabled",
+                        "smithy.api#documentation": "<p>The trace behavior for the guardrail.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration information for a guardrail that you use with the  <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html\">Converse</a> operation.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailContentBlock": {
+            "type": "union",
+            "members": {
+                "text": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailTextBlock",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Text within content block to be evaluated by the guardrail.</p>"
+                    }
+                },
+                "image": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailImageBlock",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Image within guardrail content block to be evaluated by the guardrail.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The content block to be evaluated by the guardrail.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailContentBlockList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.bedrockruntime#GuardrailContentBlock"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailContentFilter": {
+            "type": "structure",
+            "members": {
+                "type": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailContentFilterType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The guardrail type.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "confidence": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailContentFilterConfidence",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The guardrail confidence.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "filterStrength": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailContentFilterStrength",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The filter strength setting for the guardrail content filter.</p>"
+                    }
+                },
+                "action": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailContentPolicyAction",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The guardrail action.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "detected": {
+                    "target": "smithy.api#Boolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates whether content that breaches the guardrail configuration is detected.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The content filter for a guardrail.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailContentFilterConfidence": {
+            "type": "enum",
+            "members": {
+                "NONE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NONE"
+                    }
+                },
+                "LOW": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "LOW"
+                    }
+                },
+                "MEDIUM": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MEDIUM"
+                    }
+                },
+                "HIGH": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "HIGH"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailContentFilterList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.bedrockruntime#GuardrailContentFilter"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailContentFilterStrength": {
+            "type": "enum",
+            "members": {
+                "NONE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NONE"
+                    }
+                },
+                "LOW": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "LOW"
+                    }
+                },
+                "MEDIUM": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MEDIUM"
+                    }
+                },
+                "HIGH": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "HIGH"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailContentFilterType": {
+            "type": "enum",
+            "members": {
+                "INSULTS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "INSULTS"
+                    }
+                },
+                "HATE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "HATE"
+                    }
+                },
+                "SEXUAL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SEXUAL"
+                    }
+                },
+                "VIOLENCE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "VIOLENCE"
+                    }
+                },
+                "MISCONDUCT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MISCONDUCT"
+                    }
+                },
+                "PROMPT_ATTACK": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PROMPT_ATTACK"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailContentPolicyAction": {
+            "type": "enum",
+            "members": {
+                "BLOCKED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "BLOCKED"
+                    }
+                },
+                "NONE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NONE"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailContentPolicyAssessment": {
+            "type": "structure",
+            "members": {
+                "filters": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailContentFilterList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The content policy filters.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>An assessment of a content policy for a guardrail.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailContentPolicyImageUnitsProcessed": {
+            "type": "integer"
+        },
+        "com.amazonaws.bedrockruntime#GuardrailContentPolicyUnitsProcessed": {
+            "type": "integer"
+        },
+        "com.amazonaws.bedrockruntime#GuardrailContentQualifier": {
+            "type": "enum",
+            "members": {
+                "GROUNDING_SOURCE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "grounding_source"
+                    }
+                },
+                "QUERY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "query"
+                    }
+                },
+                "GUARD_CONTENT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "guard_content"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailContentQualifierList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.bedrockruntime#GuardrailContentQualifier"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailContentSource": {
+            "type": "enum",
+            "members": {
+                "INPUT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "INPUT"
+                    }
+                },
+                "OUTPUT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "OUTPUT"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailContextualGroundingFilter": {
+            "type": "structure",
+            "members": {
+                "type": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailContextualGroundingFilterType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The contextual grounding filter type.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "threshold": {
+                    "target": "smithy.api#Double",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The threshold used by contextual grounding filter to determine whether the content is grounded or not.</p>",
+                        "smithy.api#range": {
+                            "min": 0,
+                            "max": 1
+                        },
+                        "smithy.api#required": {}
+                    }
+                },
+                "score": {
+                    "target": "smithy.api#Double",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The score generated by contextual grounding filter.</p>",
+                        "smithy.api#range": {
+                            "min": 0,
+                            "max": 1
+                        },
+                        "smithy.api#required": {}
+                    }
+                },
+                "action": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailContextualGroundingPolicyAction",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The action performed by the guardrails contextual grounding filter.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "detected": {
+                    "target": "smithy.api#Boolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates whether content that fails the contextual grounding evaluation (grounding or relevance score less than the corresponding threshold) was detected.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The details for the guardrails contextual grounding filter.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailContextualGroundingFilterType": {
+            "type": "enum",
+            "members": {
+                "GROUNDING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "GROUNDING"
+                    }
+                },
+                "RELEVANCE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "RELEVANCE"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailContextualGroundingFilters": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.bedrockruntime#GuardrailContextualGroundingFilter"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailContextualGroundingPolicyAction": {
+            "type": "enum",
+            "members": {
+                "BLOCKED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "BLOCKED"
+                    }
+                },
+                "NONE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NONE"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailContextualGroundingPolicyAssessment": {
+            "type": "structure",
+            "members": {
+                "filters": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailContextualGroundingFilters",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The filter details for the guardrails contextual grounding filter.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The policy assessment details for the guardrails contextual grounding filter.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailContextualGroundingPolicyUnitsProcessed": {
+            "type": "integer"
+        },
+        "com.amazonaws.bedrockruntime#GuardrailConverseContentBlock": {
+            "type": "union",
+            "members": {
+                "text": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailConverseTextBlock",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The text to guard.</p>"
+                    }
+                },
+                "image": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailConverseImageBlock",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Image within converse content block to be evaluated by the guardrail.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p/>\n         <p>A content block for selective guarding with the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html\">Converse</a> or <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ConverseStream.html\">ConverseStream</a> API operations.\n      </p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailConverseContentQualifier": {
+            "type": "enum",
+            "members": {
+                "GROUNDING_SOURCE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "grounding_source"
+                    }
+                },
+                "QUERY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "query"
+                    }
+                },
+                "GUARD_CONTENT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "guard_content"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailConverseContentQualifierList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.bedrockruntime#GuardrailConverseContentQualifier"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailConverseImageBlock": {
+            "type": "structure",
+            "members": {
+                "format": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailConverseImageFormat",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The format details for the image type of the guardrail converse image block.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "source": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailConverseImageSource",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The image source (image bytes) of the guardrail converse image block.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>An image block that contains images that you want to assess with a guardrail.</p>",
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailConverseImageFormat": {
+            "type": "enum",
+            "members": {
+                "PNG": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "png"
+                    }
+                },
+                "JPEG": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "jpeg"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailConverseImageSource": {
+            "type": "union",
+            "members": {
+                "bytes": {
+                    "target": "smithy.api#Blob",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The raw image bytes for the image.</p>",
+                        "smithy.api#length": {
+                            "min": 1
+                        }
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The image source (image bytes) of the guardrail converse image source.</p>",
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailConverseTextBlock": {
+            "type": "structure",
+            "members": {
+                "text": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The text that you want to guard.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "qualifiers": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailConverseContentQualifierList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The qualifier details for the guardrails contextual grounding filter.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A text block that contains text that you want to assess with a guardrail. For more information, see <a>GuardrailConverseContentBlock</a>.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailCoverage": {
+            "type": "structure",
+            "members": {
+                "textCharacters": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailTextCharactersCoverage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The text characters of the guardrail coverage details.</p>"
+                    }
+                },
+                "images": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailImageCoverage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The guardrail coverage for images (the number of images that guardrails guarded).</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The action of the guardrail coverage details.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailCustomWord": {
+            "type": "structure",
+            "members": {
+                "match": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The match for the custom word.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "action": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailWordPolicyAction",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The action for the custom word.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "detected": {
+                    "target": "smithy.api#Boolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates whether custom word content that breaches the guardrail configuration is detected.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A custom word configured in a guardrail.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailCustomWordList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.bedrockruntime#GuardrailCustomWord"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailIdentifier": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "max": 2048
+                },
+                "smithy.api#pattern": "^(([a-z0-9]+)|(arn:aws(-[^:]+)?:bedrock:[a-z0-9-]{1,20}:[0-9]{12}:guardrail/[a-z0-9]+))$"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailImageBlock": {
+            "type": "structure",
+            "members": {
+                "format": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailImageFormat",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The format details for the file type of the image blocked by the guardrail.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "source": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailImageSource",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The image source (image bytes) details of the image blocked by the guardrail.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contain an image which user wants guarded. This block is accepted by the guardrails independent API.</p>",
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailImageCoverage": {
+            "type": "structure",
+            "members": {
+                "guarded": {
+                    "target": "com.amazonaws.bedrockruntime#ImagesGuarded",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The count (integer) of images guardrails guarded.</p>"
+                    }
+                },
+                "total": {
+                    "target": "com.amazonaws.bedrockruntime#ImagesTotal",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Represents the total number of images (integer) that were in the request (guarded and unguarded).</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The details of the guardrail image coverage.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailImageFormat": {
+            "type": "enum",
+            "members": {
+                "PNG": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "png"
+                    }
+                },
+                "JPEG": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "jpeg"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailImageSource": {
+            "type": "union",
+            "members": {
+                "bytes": {
+                    "target": "smithy.api#Blob",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The bytes details of the guardrail image source. Object used in independent api.</p>",
+                        "smithy.api#length": {
+                            "min": 1
+                        }
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The image source (image bytes) of the guardrail image source. Object used in independent api.</p>",
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailInvocationMetrics": {
+            "type": "structure",
+            "members": {
+                "guardrailProcessingLatency": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailProcessingLatency",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The processing latency details for the guardrail invocation metrics.</p>"
+                    }
+                },
+                "usage": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailUsage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The usage details for the guardrail invocation metrics.</p>"
+                    }
+                },
+                "guardrailCoverage": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailCoverage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The coverage details for the guardrail invocation metrics.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The invocation metrics for the guardrail.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailManagedWord": {
+            "type": "structure",
+            "members": {
+                "match": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The match for the managed word.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "type": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailManagedWordType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type for the managed word.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "action": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailWordPolicyAction",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The action for the managed word.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "detected": {
+                    "target": "smithy.api#Boolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates whether managed word content that breaches the guardrail configuration is detected.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A managed word configured in a guardrail.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailManagedWordList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.bedrockruntime#GuardrailManagedWord"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailManagedWordType": {
+            "type": "enum",
+            "members": {
+                "PROFANITY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PROFANITY"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailOutputContent": {
+            "type": "structure",
+            "members": {
+                "text": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailOutputText",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The specific text for the output content produced by the guardrail.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The output content produced by the guardrail.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailOutputContentList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.bedrockruntime#GuardrailOutputContent"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailOutputScope": {
+            "type": "enum",
+            "members": {
+                "INTERVENTIONS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "INTERVENTIONS"
+                    }
+                },
+                "FULL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FULL"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailOutputText": {
+            "type": "string"
+        },
+        "com.amazonaws.bedrockruntime#GuardrailPiiEntityFilter": {
+            "type": "structure",
+            "members": {
+                "match": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The PII entity filter match.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "type": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailPiiEntityType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The PII entity filter type.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "action": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailSensitiveInformationPolicyAction",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The PII entity filter action.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "detected": {
+                    "target": "smithy.api#Boolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates whether personally identifiable information (PII) that breaches the guardrail configuration is detected.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A Personally Identifiable Information (PII) entity configured in a guardrail.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailPiiEntityFilterList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.bedrockruntime#GuardrailPiiEntityFilter"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailPiiEntityType": {
+            "type": "enum",
+            "members": {
+                "ADDRESS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ADDRESS"
+                    }
+                },
+                "AGE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AGE"
+                    }
+                },
+                "AWS_ACCESS_KEY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AWS_ACCESS_KEY"
+                    }
+                },
+                "AWS_SECRET_KEY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AWS_SECRET_KEY"
+                    }
+                },
+                "CA_HEALTH_NUMBER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CA_HEALTH_NUMBER"
+                    }
+                },
+                "CA_SOCIAL_INSURANCE_NUMBER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CA_SOCIAL_INSURANCE_NUMBER"
+                    }
+                },
+                "CREDIT_DEBIT_CARD_CVV": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CREDIT_DEBIT_CARD_CVV"
+                    }
+                },
+                "CREDIT_DEBIT_CARD_EXPIRY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CREDIT_DEBIT_CARD_EXPIRY"
+                    }
+                },
+                "CREDIT_DEBIT_CARD_NUMBER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CREDIT_DEBIT_CARD_NUMBER"
+                    }
+                },
+                "DRIVER_ID": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DRIVER_ID"
+                    }
+                },
+                "EMAIL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "EMAIL"
+                    }
+                },
+                "INTERNATIONAL_BANK_ACCOUNT_NUMBER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "INTERNATIONAL_BANK_ACCOUNT_NUMBER"
+                    }
+                },
+                "IP_ADDRESS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "IP_ADDRESS"
+                    }
+                },
+                "LICENSE_PLATE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "LICENSE_PLATE"
+                    }
+                },
+                "MAC_ADDRESS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MAC_ADDRESS"
+                    }
+                },
+                "NAME": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NAME"
+                    }
+                },
+                "PASSWORD": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PASSWORD"
+                    }
+                },
+                "PHONE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PHONE"
+                    }
+                },
+                "PIN": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PIN"
+                    }
+                },
+                "SWIFT_CODE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SWIFT_CODE"
+                    }
+                },
+                "UK_NATIONAL_HEALTH_SERVICE_NUMBER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "UK_NATIONAL_HEALTH_SERVICE_NUMBER"
+                    }
+                },
+                "UK_NATIONAL_INSURANCE_NUMBER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "UK_NATIONAL_INSURANCE_NUMBER"
+                    }
+                },
+                "UK_UNIQUE_TAXPAYER_REFERENCE_NUMBER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "UK_UNIQUE_TAXPAYER_REFERENCE_NUMBER"
+                    }
+                },
+                "URL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "URL"
+                    }
+                },
+                "USERNAME": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "USERNAME"
+                    }
+                },
+                "US_BANK_ACCOUNT_NUMBER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "US_BANK_ACCOUNT_NUMBER"
+                    }
+                },
+                "US_BANK_ROUTING_NUMBER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "US_BANK_ROUTING_NUMBER"
+                    }
+                },
+                "US_INDIVIDUAL_TAX_IDENTIFICATION_NUMBER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "US_INDIVIDUAL_TAX_IDENTIFICATION_NUMBER"
+                    }
+                },
+                "US_PASSPORT_NUMBER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "US_PASSPORT_NUMBER"
+                    }
+                },
+                "US_SOCIAL_SECURITY_NUMBER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "US_SOCIAL_SECURITY_NUMBER"
+                    }
+                },
+                "VEHICLE_IDENTIFICATION_NUMBER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "VEHICLE_IDENTIFICATION_NUMBER"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailProcessingLatency": {
+            "type": "long"
+        },
+        "com.amazonaws.bedrockruntime#GuardrailRegexFilter": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The regex filter name.</p>"
+                    }
+                },
+                "match": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The regesx filter match.</p>"
+                    }
+                },
+                "regex": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The regex query.</p>"
+                    }
+                },
+                "action": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailSensitiveInformationPolicyAction",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The region filter action.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "detected": {
+                    "target": "smithy.api#Boolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates whether custom regex entities that breach the guardrail configuration are detected.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A Regex filter configured in a guardrail.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailRegexFilterList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.bedrockruntime#GuardrailRegexFilter"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailResource": {
+            "type": "resource",
+            "operations": [
+                {
+                    "target": "com.amazonaws.bedrockruntime#ApplyGuardrail"
+                }
+            ]
+        },
+        "com.amazonaws.bedrockruntime#GuardrailSensitiveInformationPolicyAction": {
+            "type": "enum",
+            "members": {
+                "ANONYMIZED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ANONYMIZED"
+                    }
+                },
+                "BLOCKED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "BLOCKED"
+                    }
+                },
+                "NONE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NONE"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailSensitiveInformationPolicyAssessment": {
+            "type": "structure",
+            "members": {
+                "piiEntities": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailPiiEntityFilterList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The PII entities in the assessment.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "regexes": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailRegexFilterList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The regex queries in the assessment.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The assessment for aPersonally Identifiable Information (PII) policy. </p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailSensitiveInformationPolicyFreeUnitsProcessed": {
+            "type": "integer"
+        },
+        "com.amazonaws.bedrockruntime#GuardrailSensitiveInformationPolicyUnitsProcessed": {
+            "type": "integer"
+        },
+        "com.amazonaws.bedrockruntime#GuardrailStreamConfiguration": {
+            "type": "structure",
+            "members": {
+                "guardrailIdentifier": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier for the guardrail.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "guardrailVersion": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailVersion",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the guardrail.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "trace": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailTrace",
+                    "traits": {
+                        "smithy.api#default": "disabled",
+                        "smithy.api#documentation": "<p>The trace behavior for the guardrail.</p>"
+                    }
+                },
+                "streamProcessingMode": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailStreamProcessingMode",
+                    "traits": {
+                        "smithy.api#default": "sync",
+                        "smithy.api#documentation": "<p>The processing mode. </p>\n         <p>The processing mode. For more information, see <i>Configure streaming response behavior</i> in the <i>Amazon Bedrock User Guide</i>.\n      </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration information for a guardrail that you use with the <a>ConverseStream</a> action.\n            </p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailStreamProcessingMode": {
+            "type": "enum",
+            "members": {
+                "SYNC": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "sync"
+                    }
+                },
+                "ASYNC": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "async"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailTextBlock": {
+            "type": "structure",
+            "members": {
+                "text": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The input text details to be evaluated by the guardrail.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "qualifiers": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailContentQualifierList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The qualifiers describing the text block.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The text block to be evaluated by the guardrail.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailTextCharactersCoverage": {
+            "type": "structure",
+            "members": {
+                "guarded": {
+                    "target": "com.amazonaws.bedrockruntime#TextCharactersGuarded",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The text characters that were guarded by the guardrail coverage.</p>"
+                    }
+                },
+                "total": {
+                    "target": "com.amazonaws.bedrockruntime#TextCharactersTotal",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The total text characters by the guardrail coverage.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The guardrail coverage for the text characters.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailTopic": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name for the guardrail.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "type": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailTopicType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type behavior that the guardrail should perform when the model detects the topic.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "action": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailTopicPolicyAction",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The action the guardrail should take when it intervenes on a topic.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "detected": {
+                    "target": "smithy.api#Boolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates whether topic content that breaches the guardrail configuration is detected.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about a topic guardrail.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailTopicList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.bedrockruntime#GuardrailTopic"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailTopicPolicyAction": {
+            "type": "enum",
+            "members": {
+                "BLOCKED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "BLOCKED"
+                    }
+                },
+                "NONE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NONE"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailTopicPolicyAssessment": {
+            "type": "structure",
+            "members": {
+                "topics": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailTopicList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The topics in the assessment.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A behavior assessment of a topic policy.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailTopicPolicyUnitsProcessed": {
+            "type": "integer"
+        },
+        "com.amazonaws.bedrockruntime#GuardrailTopicType": {
+            "type": "enum",
+            "members": {
+                "DENY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DENY"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailTrace": {
+            "type": "enum",
+            "members": {
+                "ENABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "enabled"
+                    }
+                },
+                "DISABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "disabled"
+                    }
+                },
+                "ENABLED_FULL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "enabled_full"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailTraceAssessment": {
+            "type": "structure",
+            "members": {
+                "modelOutput": {
+                    "target": "com.amazonaws.bedrockruntime#ModelOutputs",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The output from the model.</p>"
+                    }
+                },
+                "inputAssessment": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailAssessmentMap",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The input assessment.</p>"
+                    }
+                },
+                "outputAssessments": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailAssessmentListMap",
+                    "traits": {
+                        "smithy.api#documentation": "<p>the output assessments.</p>"
+                    }
+                },
+                "actionReason": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Provides the reason for the action taken when harmful content is detected.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A Top level guardrail trace object. For more information, see <a>ConverseTrace</a>.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailUsage": {
+            "type": "structure",
+            "members": {
+                "topicPolicyUnits": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailTopicPolicyUnitsProcessed",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The topic policy units processed by the guardrail.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "contentPolicyUnits": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailContentPolicyUnitsProcessed",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The content policy units processed by the guardrail.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "wordPolicyUnits": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailWordPolicyUnitsProcessed",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The word policy units processed by the guardrail.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "sensitiveInformationPolicyUnits": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailSensitiveInformationPolicyUnitsProcessed",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The sensitive information policy units processed by the guardrail.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "sensitiveInformationPolicyFreeUnits": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailSensitiveInformationPolicyFreeUnitsProcessed",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The sensitive information policy free units processed by the guardrail.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "contextualGroundingPolicyUnits": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailContextualGroundingPolicyUnitsProcessed",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The contextual grounding policy units processed by the guardrail.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "contentPolicyImageUnits": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailContentPolicyImageUnitsProcessed",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The content policy image units processed by the guardrail.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The details on the use of the guardrail.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailVersion": {
+            "type": "string",
+            "traits": {
+                "smithy.api#pattern": "^(([1-9][0-9]{0,7})|(DRAFT))$"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailWordPolicyAction": {
+            "type": "enum",
+            "members": {
+                "BLOCKED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "BLOCKED"
+                    }
+                },
+                "NONE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NONE"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailWordPolicyAssessment": {
+            "type": "structure",
+            "members": {
+                "customWords": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailCustomWordList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Custom words in the assessment.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "managedWordLists": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailManagedWordList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Managed word lists in the assessment.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The word policy assessment.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailWordPolicyUnitsProcessed": {
+            "type": "integer"
+        },
+        "com.amazonaws.bedrockruntime#ImageBlock": {
+            "type": "structure",
+            "members": {
+                "format": {
+                    "target": "com.amazonaws.bedrockruntime#ImageFormat",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The format of the image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "source": {
+                    "target": "com.amazonaws.bedrockruntime#ImageSource",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The source for the image.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Image content for a message.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#ImageFormat": {
+            "type": "enum",
+            "members": {
+                "PNG": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "png"
+                    }
+                },
+                "JPEG": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "jpeg"
+                    }
+                },
+                "GIF": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "gif"
+                    }
+                },
+                "WEBP": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "webp"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#ImageSource": {
+            "type": "union",
+            "members": {
+                "bytes": {
+                    "target": "smithy.api#Blob",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The raw image bytes for the image. If you use an AWS SDK, you don't need to encode the image bytes in base64.</p>",
+                        "smithy.api#length": {
+                            "min": 1
+                        }
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The source for an image.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#ImagesGuarded": {
+            "type": "integer"
+        },
+        "com.amazonaws.bedrockruntime#ImagesTotal": {
+            "type": "integer"
+        },
+        "com.amazonaws.bedrockruntime#InferenceConfiguration": {
+            "type": "structure",
+            "members": {
+                "maxTokens": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of tokens to allow in the generated response. The default value is\n         the maximum allowed value for the model that you are using. For more information, see\n            <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html\">Inference parameters for foundation models</a>. </p>",
+                        "smithy.api#range": {
+                            "min": 1
+                        }
+                    }
+                },
+                "temperature": {
+                    "target": "smithy.api#Float",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The likelihood of the model selecting higher-probability options while generating a\n         response. A lower value makes the model more likely to choose higher-probability options,\n         while a higher value makes the model more likely to choose lower-probability\n         options.</p>\n         <p>The default value is the default value for the model that\n         you are using. For more information, see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html\">Inference parameters for foundation\n            models</a>. </p>",
+                        "smithy.api#range": {
+                            "min": 0,
+                            "max": 1
+                        }
+                    }
+                },
+                "topP": {
+                    "target": "smithy.api#Float",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The percentage of most-likely candidates that the model considers for the next token. For\n         example, if you choose a value of 0.8 for <code>topP</code>, the model selects from the top 80% of the\n         probability distribution of tokens that could be next in the sequence.</p>\n         <p>The default value is the default value for the model that you are using. For more information, see\n         <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html\">Inference parameters for foundation models</a>. </p>",
+                        "smithy.api#range": {
+                            "min": 0,
+                            "max": 1
+                        }
+                    }
+                },
+                "stopSequences": {
+                    "target": "com.amazonaws.bedrockruntime#NonEmptyStringList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of stop sequences. A stop sequence is a sequence of characters that causes the\n         model to stop generating the response. </p>",
+                        "smithy.api#length": {
+                            "max": 4
+                        }
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Base inference parameters to pass to a model in a call to <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html\">Converse</a> or <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ConverseStream.html\">ConverseStream</a>. For more information,\n         see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html\">Inference parameters for foundation models</a>.</p>\n         <p>If you need to pass additional parameters that the model\n         supports, use the <code>additionalModelRequestFields</code> request field in the call to <code>Converse</code>\n         or <code>ConverseStream</code>.\n         For more information, see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html\">Model parameters</a>.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#InferenceResource": {
+            "type": "resource",
+            "operations": [
+                {
+                    "target": "com.amazonaws.bedrockruntime#Converse"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ConverseStream"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#InvokeModel"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#InvokeModelWithBidirectionalStream"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#InvokeModelWithResponseStream"
+                }
+            ]
+        },
+        "com.amazonaws.bedrockruntime#InternalServerException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.bedrockruntime#NonBlankString"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>An internal server error occurred. For troubleshooting this error, \n         see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/troubleshooting-api-error-codes.html#ts-internal-failure\">InternalFailure</a> in the Amazon Bedrock User Guide</p>",
+                "smithy.api#error": "server",
+                "smithy.api#httpError": 500
+            }
+        },
+        "com.amazonaws.bedrockruntime#InvocationArn": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 2048
+                },
+                "smithy.api#pattern": "^arn:aws(-[^:]+)?:bedrock:[a-z0-9-]{1,20}:[0-9]{12}:async-invoke/[a-z0-9]{12}$"
+            }
+        },
+        "com.amazonaws.bedrockruntime#InvokeModel": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.bedrockruntime#InvokeModelRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.bedrockruntime#InvokeModelResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.bedrockruntime#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ModelErrorException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ModelNotReadyException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ModelTimeoutException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ServiceUnavailableException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Invokes the specified Amazon Bedrock model to run inference using the prompt and inference parameters provided in the request body. \n         You use model inference to generate text, images, and embeddings.</p>\n         <p>For example code, see <i>Invoke model code examples</i> in the <i>Amazon Bedrock User Guide</i>.\n      </p>\n         <p>This operation requires permission for the <code>bedrock:InvokeModel</code> action.</p>\n         <important>\n            <p>To deny all inference access to resources that you specify in the modelId field, you\n         need to deny access to the <code>bedrock:InvokeModel</code> and\n            <code>bedrock:InvokeModelWithResponseStream</code> actions. Doing this also denies\n         access to the resource through the Converse API actions (<a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html\">Converse</a> and <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ConverseStream.html\">ConverseStream</a>). For more information see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/security_iam_id-based-policy-examples.html#security_iam_id-based-policy-examples-deny-inference\">Deny access for inference on specific models</a>.\n            </p>\n         </important>\n         <p>For troubleshooting some of the common errors you might encounter when using the <code>InvokeModel</code> API, \n         see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/troubleshooting-api-error-codes.html\">Troubleshooting Amazon Bedrock API Error Codes</a> in the Amazon Bedrock User Guide</p>",
+                "smithy.api#http": {
+                    "code": 200,
+                    "method": "POST",
+                    "uri": "/model/{modelId}/invoke"
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#InvokeModelIdentifier": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 2048
+                },
+                "smithy.api#pattern": "^(arn:aws(-[^:]+)?:bedrock:[a-z0-9-]{1,20}:(([0-9]{12}:custom-model/[a-z0-9-]{1,63}[.]{1}[a-z0-9-]{1,63}/[a-z0-9]{12})|(:foundation-model/[a-z0-9-]{1,63}[.]{1}[a-z0-9-]{1,63}([.:]?[a-z0-9-]{1,63}))|([0-9]{12}:imported-model/[a-z0-9]{12})|([0-9]{12}:provisioned-model/[a-z0-9]{12})|([0-9]{12}:(inference-profile|application-inference-profile)/[a-zA-Z0-9-:.]+)))|([a-z0-9-]{1,63}[.]{1}[a-z0-9-]{1,63}([.:]?[a-z0-9-]{1,63}))|(([0-9a-zA-Z][_-]?)+)|([a-zA-Z0-9-:.]+)$|(^(arn:aws(-[^:]+)?:bedrock:[a-z0-9-]{1,20}:[0-9]{12}:prompt/[0-9a-zA-Z]{10}(?::[0-9]{1,5})?))$|(^arn:aws:sagemaker:[a-z0-9-]+:[0-9]{12}:endpoint/[a-zA-Z0-9-]+$)|(^arn:aws(-[^:]+)?:bedrock:([0-9a-z-]{1,20}):([0-9]{12}):(default-)?prompt-router/[a-zA-Z0-9-:.]+$)$"
+            }
+        },
+        "com.amazonaws.bedrockruntime#InvokeModelRequest": {
+            "type": "structure",
+            "members": {
+                "body": {
+                    "target": "com.amazonaws.bedrockruntime#Body",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The prompt and inference parameters in the format specified in the <code>contentType</code> in the header. You must provide the body in JSON format. To see the format and content of the request and response bodies for different models, refer to <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html\">Inference parameters</a>. For more information, see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/api-methods-run.html\">Run inference</a> in the Bedrock User Guide.</p>",
+                        "smithy.api#httpPayload": {}
+                    }
+                },
+                "contentType": {
+                    "target": "com.amazonaws.bedrockruntime#MimeType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The MIME type of the input data in the request. You must specify\n            <code>application/json</code>.</p>",
+                        "smithy.api#httpHeader": "Content-Type"
+                    }
+                },
+                "accept": {
+                    "target": "com.amazonaws.bedrockruntime#MimeType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The desired MIME type of the inference body in the response. The default value is <code>application/json</code>.</p>",
+                        "smithy.api#httpHeader": "Accept"
+                    }
+                },
+                "modelId": {
+                    "target": "com.amazonaws.bedrockruntime#InvokeModelIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the model to invoke to run inference.</p>\n         <p>The <code>modelId</code> to provide depends on the type of model or throughput that you use:</p>\n         <ul>\n            <li>\n               <p>If you use a base model, specify the model ID or its ARN. For a list of model IDs for base models, see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html#model-ids-arns\">Amazon Bedrock base model IDs (on-demand throughput)</a> in the Amazon Bedrock User Guide.</p>\n            </li>\n            <li>\n               <p>If you use an inference profile, specify the inference profile ID or its ARN. For a list of inference profile IDs, see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html\">Supported Regions and models for cross-region inference</a> in the Amazon Bedrock User Guide.</p>\n            </li>\n            <li>\n               <p>If you use a provisioned model, specify the ARN of the Provisioned Throughput. For more information, see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/prov-thru-use.html\">Run inference using a Provisioned Throughput</a> in the Amazon Bedrock User Guide.</p>\n            </li>\n            <li>\n               <p>If you use a custom model, first purchase Provisioned Throughput for it. Then specify the ARN of the resulting provisioned model. For more information, see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-use.html\">Use a custom model in Amazon Bedrock</a> in the Amazon Bedrock User Guide.</p>\n            </li>\n            <li>\n               <p>If you use an <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-import-model.html\">imported model</a>, specify the ARN of the imported model. You can get the model ARN from a successful call to <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_CreateModelImportJob.html\">CreateModelImportJob</a> or from the Imported models page in the Amazon Bedrock console.</p>\n            </li>\n         </ul>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "trace": {
+                    "target": "com.amazonaws.bedrockruntime#Trace",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies whether to enable or disable the Bedrock trace. If enabled, you can see the full Bedrock trace.</p>",
+                        "smithy.api#httpHeader": "X-Amzn-Bedrock-Trace"
+                    }
+                },
+                "guardrailIdentifier": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the guardrail that you want to use. If you don't provide a value, no guardrail is applied\n            to the invocation.</p>\n         <p>An error will be thrown in the following situations.</p>\n         <ul>\n            <li>\n               <p>You don't provide a guardrail identifier but you specify the <code>amazon-bedrock-guardrailConfig</code> field in the request body.</p>\n            </li>\n            <li>\n               <p>You enable the guardrail but the <code>contentType</code> isn't <code>application/json</code>.</p>\n            </li>\n            <li>\n               <p>You provide a guardrail identifier, but <code>guardrailVersion</code> isn't specified.</p>\n            </li>\n         </ul>",
+                        "smithy.api#httpHeader": "X-Amzn-Bedrock-GuardrailIdentifier"
+                    }
+                },
+                "guardrailVersion": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailVersion",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version number for the guardrail. The value can also be <code>DRAFT</code>.</p>",
+                        "smithy.api#httpHeader": "X-Amzn-Bedrock-GuardrailVersion"
+                    }
+                },
+                "performanceConfigLatency": {
+                    "target": "com.amazonaws.bedrockruntime#PerformanceConfigLatency",
+                    "traits": {
+                        "smithy.api#default": "standard",
+                        "smithy.api#documentation": "<p>Model performance settings for the request.</p>",
+                        "smithy.api#httpHeader": "X-Amzn-Bedrock-PerformanceConfig-Latency"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#InvokeModelResponse": {
+            "type": "structure",
+            "members": {
+                "body": {
+                    "target": "com.amazonaws.bedrockruntime#Body",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Inference response from the model in the format specified in the <code>contentType</code> header. To see the format and content of the request and response bodies for different models, refer to <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html\">Inference parameters</a>.</p>",
+                        "smithy.api#httpPayload": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "contentType": {
+                    "target": "com.amazonaws.bedrockruntime#MimeType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The MIME type of the inference result.</p>",
+                        "smithy.api#httpHeader": "Content-Type",
+                        "smithy.api#required": {}
+                    }
+                },
+                "performanceConfigLatency": {
+                    "target": "com.amazonaws.bedrockruntime#PerformanceConfigLatency",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Model performance settings for the request.</p>",
+                        "smithy.api#httpHeader": "X-Amzn-Bedrock-PerformanceConfig-Latency"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#InvokeModelWithBidirectionalStream": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.bedrockruntime#InvokeModelWithBidirectionalStreamRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.bedrockruntime#InvokeModelWithBidirectionalStreamResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.bedrockruntime#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ModelErrorException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ModelNotReadyException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ModelStreamErrorException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ModelTimeoutException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ServiceUnavailableException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Invoke the specified Amazon Bedrock model to run inference using the bidirectional stream. The response is returned in a stream that remains open for 8 minutes. A single session can contain multiple prompts and responses from the model. The prompts to the model are provided as audio files and the model's responses are spoken back to the user and transcribed.</p>\n         <p>It is possible for users to interrupt the model's response with a new prompt, which will halt the response speech. The model will retain contextual awareness of the conversation while pivoting to respond to the new prompt.</p>",
+                "smithy.api#http": {
+                    "code": 200,
+                    "method": "POST",
+                    "uri": "/model/{modelId}/invoke-with-bidirectional-stream"
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#InvokeModelWithBidirectionalStreamInput": {
+            "type": "union",
+            "members": {
+                "chunk": {
+                    "target": "com.amazonaws.bedrockruntime#BidirectionalInputPayloadPart",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The audio chunk that is used as input for the invocation step.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Payload content, the speech chunk, for the bidirectional input of the invocation step.</p>",
+                "smithy.api#streaming": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#InvokeModelWithBidirectionalStreamOutput": {
+            "type": "union",
+            "members": {
+                "chunk": {
+                    "target": "com.amazonaws.bedrockruntime#BidirectionalOutputPayloadPart",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The speech chunk that was provided as output from the invocation step.</p>"
+                    }
+                },
+                "internalServerException": {
+                    "target": "com.amazonaws.bedrockruntime#InternalServerException",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The request encountered an unknown internal error.</p>"
+                    }
+                },
+                "modelStreamErrorException": {
+                    "target": "com.amazonaws.bedrockruntime#ModelStreamErrorException",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The request encountered an error with the model stream.</p>"
+                    }
+                },
+                "validationException": {
+                    "target": "com.amazonaws.bedrockruntime#ValidationException",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The input fails to satisfy the constraints specified by an Amazon Web Services service.</p>"
+                    }
+                },
+                "throttlingException": {
+                    "target": "com.amazonaws.bedrockruntime#ThrottlingException",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The request was denied due to request throttling.</p>"
+                    }
+                },
+                "modelTimeoutException": {
+                    "target": "com.amazonaws.bedrockruntime#ModelTimeoutException",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The connection was closed because a request was not received within the timeout period.</p>"
+                    }
+                },
+                "serviceUnavailableException": {
+                    "target": "com.amazonaws.bedrockruntime#ServiceUnavailableException",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The request has failed due to a temporary failure of the server.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Output from the bidirectional stream that was used for model invocation.</p>",
+                "smithy.api#streaming": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#InvokeModelWithBidirectionalStreamRequest": {
+            "type": "structure",
+            "members": {
+                "modelId": {
+                    "target": "com.amazonaws.bedrockruntime#InvokeModelIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The model ID or ARN of the model ID to use. Currently, only <code>amazon.nova-sonic-v1:0</code> is supported.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "body": {
+                    "target": "com.amazonaws.bedrockruntime#InvokeModelWithBidirectionalStreamInput",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The prompt and inference parameters in the format specified in the <code>BidirectionalInputPayloadPart</code> in the header. You must provide the body in JSON format. To see the format and content of the request and response bodies for different models, refer to <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html\">Inference parameters</a>. For more information, see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/api-methods-run.html\">Run inference</a> in the Bedrock User Guide.</p>",
+                        "smithy.api#httpPayload": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#InvokeModelWithBidirectionalStreamResponse": {
+            "type": "structure",
+            "members": {
+                "body": {
+                    "target": "com.amazonaws.bedrockruntime#InvokeModelWithBidirectionalStreamOutput",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Streaming response from the model in the format specified by the <code>BidirectionalOutputPayloadPart</code> header.</p>",
+                        "smithy.api#httpPayload": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#InvokeModelWithResponseStream": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.bedrockruntime#InvokeModelWithResponseStreamRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.bedrockruntime#InvokeModelWithResponseStreamResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.bedrockruntime#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ModelErrorException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ModelNotReadyException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ModelStreamErrorException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ModelTimeoutException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ServiceUnavailableException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Invoke the specified Amazon Bedrock model to run inference using the prompt and inference parameters provided in the request body. The response is returned in a stream.</p>\n         <p>To see if a model supports streaming, call <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_GetFoundationModel.html\">GetFoundationModel</a>\n         and check the <code>responseStreamingSupported</code> field in the response.</p>\n         <note>\n            <p>The CLI doesn't support streaming operations in Amazon Bedrock, including <code>InvokeModelWithResponseStream</code>.</p>\n         </note>\n         <p>For example code, see <i>Invoke model with streaming code\n         example</i> in the <i>Amazon Bedrock User Guide</i>.\n      </p>\n         <p>This operation requires permissions to perform the <code>bedrock:InvokeModelWithResponseStream</code> action. </p>\n         <important>\n            <p>To deny all inference access to resources that you specify in the modelId field, you\n         need to deny access to the <code>bedrock:InvokeModel</code> and\n            <code>bedrock:InvokeModelWithResponseStream</code> actions. Doing this also denies\n         access to the resource through the Converse API actions (<a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html\">Converse</a> and <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ConverseStream.html\">ConverseStream</a>). For more information see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/security_iam_id-based-policy-examples.html#security_iam_id-based-policy-examples-deny-inference\">Deny access for inference on specific models</a>.\n            </p>\n         </important>\n         <p>For troubleshooting some of the common errors you might encounter when using the <code>InvokeModelWithResponseStream</code> API, \n         see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/troubleshooting-api-error-codes.html\">Troubleshooting Amazon Bedrock API Error Codes</a> in the Amazon Bedrock User Guide</p>",
+                "smithy.api#http": {
+                    "code": 200,
+                    "method": "POST",
+                    "uri": "/model/{modelId}/invoke-with-response-stream"
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#InvokeModelWithResponseStreamRequest": {
+            "type": "structure",
+            "members": {
+                "body": {
+                    "target": "com.amazonaws.bedrockruntime#Body",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The prompt and inference parameters in the format specified in the <code>contentType</code> in the header. You must provide the body in JSON format. To see the format and content of the request and response bodies for different models, refer to <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html\">Inference parameters</a>. For more information, see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/api-methods-run.html\">Run inference</a> in the Bedrock User Guide.</p>",
+                        "smithy.api#httpPayload": {}
+                    }
+                },
+                "contentType": {
+                    "target": "com.amazonaws.bedrockruntime#MimeType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The MIME type of the input data in the request. You must specify\n            <code>application/json</code>.</p>",
+                        "smithy.api#httpHeader": "Content-Type"
+                    }
+                },
+                "accept": {
+                    "target": "com.amazonaws.bedrockruntime#MimeType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The desired MIME type of the inference body in the response. The default value is\n            <code>application/json</code>.</p>",
+                        "smithy.api#httpHeader": "X-Amzn-Bedrock-Accept"
+                    }
+                },
+                "modelId": {
+                    "target": "com.amazonaws.bedrockruntime#InvokeModelIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the model to invoke to run inference.</p>\n         <p>The <code>modelId</code> to provide depends on the type of model or throughput that you use:</p>\n         <ul>\n            <li>\n               <p>If you use a base model, specify the model ID or its ARN. For a list of model IDs for base models, see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html#model-ids-arns\">Amazon Bedrock base model IDs (on-demand throughput)</a> in the Amazon Bedrock User Guide.</p>\n            </li>\n            <li>\n               <p>If you use an inference profile, specify the inference profile ID or its ARN. For a list of inference profile IDs, see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html\">Supported Regions and models for cross-region inference</a> in the Amazon Bedrock User Guide.</p>\n            </li>\n            <li>\n               <p>If you use a provisioned model, specify the ARN of the Provisioned Throughput. For more information, see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/prov-thru-use.html\">Run inference using a Provisioned Throughput</a> in the Amazon Bedrock User Guide.</p>\n            </li>\n            <li>\n               <p>If you use a custom model, first purchase Provisioned Throughput for it. Then specify the ARN of the resulting provisioned model. For more information, see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-use.html\">Use a custom model in Amazon Bedrock</a> in the Amazon Bedrock User Guide.</p>\n            </li>\n            <li>\n               <p>If you use an <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-import-model.html\">imported model</a>, specify the ARN of the imported model. You can get the model ARN from a successful call to <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_CreateModelImportJob.html\">CreateModelImportJob</a> or from the Imported models page in the Amazon Bedrock console.</p>\n            </li>\n         </ul>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "trace": {
+                    "target": "com.amazonaws.bedrockruntime#Trace",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies whether to enable or disable the Bedrock trace. If enabled, you can see the full Bedrock trace.</p>",
+                        "smithy.api#httpHeader": "X-Amzn-Bedrock-Trace"
+                    }
+                },
+                "guardrailIdentifier": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the guardrail that you want to use. If you don't provide a value, no guardrail is applied\n            to the invocation.</p>\n         <p>An error is thrown in the following situations.</p>\n         <ul>\n            <li>\n               <p>You don't provide a guardrail identifier but you specify the <code>amazon-bedrock-guardrailConfig</code> field in the request body.</p>\n            </li>\n            <li>\n               <p>You enable the guardrail but the <code>contentType</code> isn't <code>application/json</code>.</p>\n            </li>\n            <li>\n               <p>You provide a guardrail identifier, but <code>guardrailVersion</code> isn't specified.</p>\n            </li>\n         </ul>",
+                        "smithy.api#httpHeader": "X-Amzn-Bedrock-GuardrailIdentifier"
+                    }
+                },
+                "guardrailVersion": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailVersion",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version number for the guardrail. The value can also be <code>DRAFT</code>.</p>",
+                        "smithy.api#httpHeader": "X-Amzn-Bedrock-GuardrailVersion"
+                    }
+                },
+                "performanceConfigLatency": {
+                    "target": "com.amazonaws.bedrockruntime#PerformanceConfigLatency",
+                    "traits": {
+                        "smithy.api#default": "standard",
+                        "smithy.api#documentation": "<p>Model performance settings for the request.</p>",
+                        "smithy.api#httpHeader": "X-Amzn-Bedrock-PerformanceConfig-Latency"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#InvokeModelWithResponseStreamResponse": {
+            "type": "structure",
+            "members": {
+                "body": {
+                    "target": "com.amazonaws.bedrockruntime#ResponseStream",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Inference response from the model in the format specified by the <code>contentType</code> header. To see the format and content of this field for different models, refer to <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html\">Inference parameters</a>.</p>",
+                        "smithy.api#httpPayload": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "contentType": {
+                    "target": "com.amazonaws.bedrockruntime#MimeType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The MIME type of the inference result.</p>",
+                        "smithy.api#httpHeader": "X-Amzn-Bedrock-Content-Type",
+                        "smithy.api#required": {}
+                    }
+                },
+                "performanceConfigLatency": {
+                    "target": "com.amazonaws.bedrockruntime#PerformanceConfigLatency",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Model performance settings for the request.</p>",
+                        "smithy.api#httpHeader": "X-Amzn-Bedrock-PerformanceConfig-Latency"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#InvokedModelId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#pattern": "^(arn:aws(-[^:]+)?:bedrock:[a-z0-9-]{1,20}::foundation-model/[a-z0-9-]{1,63}[.]{1}[a-z0-9-]{1,63}([a-z0-9-]{1,63}[.]){0,2}[a-z0-9-]{1,63}([:][a-z0-9-]{1,63}){0,2})|(arn:aws(|-us-gov|-cn|-iso|-iso-b):bedrock:(|[0-9a-z-]{1,20}):(|[0-9]{12}):inference-profile/[a-zA-Z0-9-:.]+)$"
+            }
+        },
+        "com.amazonaws.bedrockruntime#KmsKeyId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 2048
+                },
+                "smithy.api#pattern": "^arn:aws(-[^:]+)?:kms:[a-zA-Z0-9-]*:[0-9]{12}:((key/[a-zA-Z0-9-]{36})|(alias/[a-zA-Z0-9-_/]+))$"
+            }
+        },
+        "com.amazonaws.bedrockruntime#ListAsyncInvokes": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.bedrockruntime#ListAsyncInvokesRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.bedrockruntime#ListAsyncInvokesResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.bedrockruntime#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists asynchronous invocations.</p>",
+                "smithy.api#http": {
+                    "code": 200,
+                    "method": "GET",
+                    "uri": "/async-invoke"
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "asyncInvokeSummaries"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#ListAsyncInvokesRequest": {
+            "type": "structure",
+            "members": {
+                "submitTimeAfter": {
+                    "target": "com.amazonaws.bedrockruntime#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Include invocations submitted after this time.</p>",
+                        "smithy.api#httpQuery": "submitTimeAfter"
+                    }
+                },
+                "submitTimeBefore": {
+                    "target": "com.amazonaws.bedrockruntime#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Include invocations submitted before this time.</p>",
+                        "smithy.api#httpQuery": "submitTimeBefore"
+                    }
+                },
+                "statusEquals": {
+                    "target": "com.amazonaws.bedrockruntime#AsyncInvokeStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Filter invocations by status.</p>",
+                        "smithy.api#httpQuery": "statusEquals"
+                    }
+                },
+                "maxResults": {
+                    "target": "com.amazonaws.bedrockruntime#MaxResults",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of invocations to return in one page of results.</p>",
+                        "smithy.api#httpQuery": "maxResults"
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.bedrockruntime#PaginationToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specify the pagination token from a previous request to retrieve the next page of results.</p>",
+                        "smithy.api#httpQuery": "nextToken"
+                    }
+                },
+                "sortBy": {
+                    "target": "com.amazonaws.bedrockruntime#SortAsyncInvocationBy",
+                    "traits": {
+                        "smithy.api#default": "SubmissionTime",
+                        "smithy.api#documentation": "<p>How to sort the response.</p>",
+                        "smithy.api#httpQuery": "sortBy"
+                    }
+                },
+                "sortOrder": {
+                    "target": "com.amazonaws.bedrockruntime#SortOrder",
+                    "traits": {
+                        "smithy.api#default": "Descending",
+                        "smithy.api#documentation": "<p>The sorting order for the response.</p>",
+                        "smithy.api#httpQuery": "sortOrder"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#ListAsyncInvokesResponse": {
+            "type": "structure",
+            "members": {
+                "nextToken": {
+                    "target": "com.amazonaws.bedrockruntime#PaginationToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specify the pagination token from a previous request to retrieve the next page of results.</p>"
+                    }
+                },
+                "asyncInvokeSummaries": {
+                    "target": "com.amazonaws.bedrockruntime#AsyncInvokeSummaries",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of invocation summaries.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#MaxResults": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 1000
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#Message": {
+            "type": "structure",
+            "members": {
+                "role": {
+                    "target": "com.amazonaws.bedrockruntime#ConversationRole",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The role that the message plays in the message.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "content": {
+                    "target": "com.amazonaws.bedrockruntime#ContentBlocks",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The message content. Note the following restrictions:</p>\n         <ul>\n            <li>\n               <p>You can include up to 20 images. Each image's size, height, and width must be no more than 3.75 MB, 8000 px, and 8000 px, respectively.</p>\n            </li>\n            <li>\n               <p>You can include up to five documents. Each document's size must be no more than 4.5 MB.</p>\n            </li>\n            <li>\n               <p>If you include a <code>ContentBlock</code> with a <code>document</code> field in the array, you must also include a <code>ContentBlock</code> with a <code>text</code> field.</p>\n            </li>\n            <li>\n               <p>You can only include images and documents if the <code>role</code> is <code>user</code>.</p>\n            </li>\n         </ul>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A message input, or returned from, a call to <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html\">Converse</a> or <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ConverseStream.html\">ConverseStream</a>.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#MessageStartEvent": {
+            "type": "structure",
+            "members": {
+                "role": {
+                    "target": "com.amazonaws.bedrockruntime#ConversationRole",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The role for the message.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The start of a message.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#MessageStopEvent": {
+            "type": "structure",
+            "members": {
+                "stopReason": {
+                    "target": "com.amazonaws.bedrockruntime#StopReason",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The reason why the model stopped generating output.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "additionalModelResponseFields": {
+                    "target": "smithy.api#Document",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The additional model response fields.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The stop event for a message.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#Messages": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.bedrockruntime#Message"
+            }
+        },
+        "com.amazonaws.bedrockruntime#MimeType": {
+            "type": "string"
+        },
+        "com.amazonaws.bedrockruntime#ModelErrorException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.bedrockruntime#NonBlankString"
+                },
+                "originalStatusCode": {
+                    "target": "com.amazonaws.bedrockruntime#StatusCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The original status code.</p>"
+                    }
+                },
+                "resourceName": {
+                    "target": "com.amazonaws.bedrockruntime#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The resource name.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The request failed due to an error while processing the model.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 424
+            }
+        },
+        "com.amazonaws.bedrockruntime#ModelInputPayload": {
+            "type": "document",
+            "traits": {
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#ModelNotReadyException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.bedrockruntime#NonBlankString"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The model specified in the request is not ready to serve inference requests. The AWS SDK\n         will automatically retry the operation up to 5 times. For information about configuring\n         automatic retries, see <a href=\"https://docs.aws.amazon.com/sdkref/latest/guide/feature-retry-behavior.html\">Retry behavior</a> in the <i>AWS SDKs and Tools</i>\n      reference guide.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 429,
+                "smithy.api#retryable": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#ModelOutputs": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.bedrockruntime#GuardrailOutputText"
+            }
+        },
+        "com.amazonaws.bedrockruntime#ModelStreamErrorException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.bedrockruntime#NonBlankString"
+                },
+                "originalStatusCode": {
+                    "target": "com.amazonaws.bedrockruntime#StatusCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The original status code.</p>"
+                    }
+                },
+                "originalMessage": {
+                    "target": "com.amazonaws.bedrockruntime#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The original message.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>An error occurred while streaming the response. Retry your request.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 424
+            }
+        },
+        "com.amazonaws.bedrockruntime#ModelTimeoutException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.bedrockruntime#NonBlankString"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The request took too long to process. Processing time exceeded the model timeout length.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 408
+            }
+        },
+        "com.amazonaws.bedrockruntime#NonBlankString": {
+            "type": "string",
+            "traits": {
+                "smithy.api#pattern": "^[\\s\\S]*$"
+            }
+        },
+        "com.amazonaws.bedrockruntime#NonEmptyString": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#NonEmptyStringList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.bedrockruntime#NonEmptyString"
+            }
+        },
+        "com.amazonaws.bedrockruntime#NonNegativeInteger": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 0
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#PaginationToken": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 2048
+                },
+                "smithy.api#pattern": "^\\S*$"
+            }
+        },
+        "com.amazonaws.bedrockruntime#PartBody": {
+            "type": "blob",
+            "traits": {
+                "smithy.api#length": {
+                    "max": 1000000
+                },
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#PayloadPart": {
+            "type": "structure",
+            "members": {
+                "bytes": {
+                    "target": "com.amazonaws.bedrockruntime#PartBody",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Base64-encoded bytes of payload data.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Payload content included in the response.</p>",
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#PerformanceConfigLatency": {
+            "type": "enum",
+            "members": {
+                "STANDARD": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "standard"
+                    }
+                },
+                "OPTIMIZED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "optimized"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#PerformanceConfiguration": {
+            "type": "structure",
+            "members": {
+                "latency": {
+                    "target": "com.amazonaws.bedrockruntime#PerformanceConfigLatency",
+                    "traits": {
+                        "smithy.api#default": "standard",
+                        "smithy.api#documentation": "<p>To use a latency-optimized version of the model, set to <code>optimized</code>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Performance settings for a model.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#PromptRouterTrace": {
+            "type": "structure",
+            "members": {
+                "invokedModelId": {
+                    "target": "com.amazonaws.bedrockruntime#InvokedModelId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the invoked model.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A prompt router trace.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#PromptVariableMap": {
+            "type": "map",
+            "key": {
+                "target": "smithy.api#String"
+            },
+            "value": {
+                "target": "com.amazonaws.bedrockruntime#PromptVariableValues"
+            },
+            "traits": {
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#PromptVariableValues": {
+            "type": "union",
+            "members": {
+                "text": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The text value that the variable maps to.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains a map of variables in a prompt from Prompt management to an object containing the values to fill in for them when running model invocation. For more information, see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-management-how.html\">How Prompt management works</a>.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#ReasoningContentBlock": {
+            "type": "union",
+            "members": {
+                "reasoningText": {
+                    "target": "com.amazonaws.bedrockruntime#ReasoningTextBlock",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The reasoning that the model used to return the output.</p>"
+                    }
+                },
+                "redactedContent": {
+                    "target": "smithy.api#Blob",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The content in the reasoning that was encrypted by the model provider for safety reasons. The encryption doesn't affect the quality of responses.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains content regarding the reasoning that is carried out by the model with respect to the content in the content block. Reasoning refers to a Chain of Thought (CoT) that the model generates to enhance the accuracy of its final response.</p>",
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#ReasoningContentBlockDelta": {
+            "type": "union",
+            "members": {
+                "text": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The reasoning that the model used to return the output.</p>"
+                    }
+                },
+                "redactedContent": {
+                    "target": "smithy.api#Blob",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The content in the reasoning that was encrypted by the model provider for safety reasons. The encryption doesn't affect the quality of responses.</p>"
+                    }
+                },
+                "signature": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token that verifies that the reasoning text was generated by the model. If you pass a reasoning block back to the API in a multi-turn conversation, include the text and its signature unmodified.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains content regarding the reasoning that is carried out by the model with respect to the content in the content block. Reasoning refers to a Chain of Thought (CoT) that the model generates to enhance the accuracy of its final response.</p>",
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#ReasoningTextBlock": {
+            "type": "structure",
+            "members": {
+                "text": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The reasoning that the model used to return the output.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "signature": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token that verifies that the reasoning text was generated by the model. If you pass a reasoning block back to the API in a multi-turn conversation, include the text and its signature unmodified.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains the reasoning that the model used to return the output.</p>",
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#RequestMetadata": {
+            "type": "map",
+            "key": {
+                "target": "smithy.api#String",
+                "traits": {
+                    "smithy.api#length": {
+                        "min": 1,
+                        "max": 256
+                    },
+                    "smithy.api#pattern": "^[a-zA-Z0-9\\s:_@$#=/+,-.]{1,256}$"
+                }
+            },
+            "value": {
+                "target": "smithy.api#String",
+                "traits": {
+                    "smithy.api#length": {
+                        "min": 0,
+                        "max": 256
+                    },
+                    "smithy.api#pattern": "^[a-zA-Z0-9\\s:_@$#=/+,-.]{0,256}$"
+                }
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 16
+                },
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#ResourceNotFoundException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.bedrockruntime#NonBlankString"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The specified resource ARN was not found. For troubleshooting this error, \n         see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/troubleshooting-api-error-codes.html#ts-resource-not-found\">ResourceNotFound</a> in the Amazon Bedrock User Guide</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 404
+            }
+        },
+        "com.amazonaws.bedrockruntime#ResponseStream": {
+            "type": "union",
+            "members": {
+                "chunk": {
+                    "target": "com.amazonaws.bedrockruntime#PayloadPart",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Content included in the response.</p>"
+                    }
+                },
+                "internalServerException": {
+                    "target": "com.amazonaws.bedrockruntime#InternalServerException",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An internal server error occurred. Retry your request.</p>"
+                    }
+                },
+                "modelStreamErrorException": {
+                    "target": "com.amazonaws.bedrockruntime#ModelStreamErrorException",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An error occurred while streaming the response. Retry your request.</p>"
+                    }
+                },
+                "validationException": {
+                    "target": "com.amazonaws.bedrockruntime#ValidationException",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Input validation failed. Check your request parameters and retry the request.</p>"
+                    }
+                },
+                "throttlingException": {
+                    "target": "com.amazonaws.bedrockruntime#ThrottlingException",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Your request was throttled because of service-wide limitations. Resubmit your request later or in a different region. You can also purchase <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/prov-throughput.html\">Provisioned Throughput</a> to increase the rate or number of tokens you can process.</p>"
+                    }
+                },
+                "modelTimeoutException": {
+                    "target": "com.amazonaws.bedrockruntime#ModelTimeoutException",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The request took too long to process. Processing time exceeded the model timeout length.</p>"
+                    }
+                },
+                "serviceUnavailableException": {
+                    "target": "com.amazonaws.bedrockruntime#ServiceUnavailableException",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The service isn't available. Try again later.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Definition of content in the response stream.</p>",
+                "smithy.api#streaming": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#S3Location": {
+            "type": "structure",
+            "members": {
+                "uri": {
+                    "target": "com.amazonaws.bedrockruntime#S3Uri",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An object URI starting with <code>s3://</code>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "bucketOwner": {
+                    "target": "com.amazonaws.bedrockruntime#AccountId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the bucket belongs to another AWS account, specify that account's ID.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A storage location in an S3 bucket.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#S3Uri": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1024
+                },
+                "smithy.api#pattern": "^s3://[a-z0-9][\\.\\-a-z0-9]{1,61}[a-z0-9](/.*)?$"
+            }
+        },
+        "com.amazonaws.bedrockruntime#ServiceQuotaExceededException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.bedrockruntime#NonBlankString"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Your request exceeds the service quota for your account. You can view your quotas at <a href=\"https://docs.aws.amazon.com/servicequotas/latest/userguide/gs-request-quota.html\">Viewing service quotas</a>. You can resubmit your request later.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.bedrockruntime#ServiceUnavailableException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.bedrockruntime#NonBlankString"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The service isn't currently available. For troubleshooting this error, \n         see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/troubleshooting-api-error-codes.html#ts-service-unavailable\">ServiceUnavailable</a> in the Amazon Bedrock User Guide</p>",
+                "smithy.api#error": "server",
+                "smithy.api#httpError": 503
+            }
+        },
+        "com.amazonaws.bedrockruntime#SortAsyncInvocationBy": {
+            "type": "enum",
+            "members": {
+                "SUBMISSION_TIME": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SubmissionTime"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#SortOrder": {
+            "type": "enum",
+            "members": {
+                "ASCENDING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Ascending"
+                    }
+                },
+                "DESCENDING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Descending"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#SpecificToolChoice": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "com.amazonaws.bedrockruntime#ToolName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the tool that the model must request. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The model must request a specific tool.  For example, <code>{\"tool\" : {\"name\" : \"Your tool name\"}}</code>.</p>\n         <note>\n            <p>This field is only supported by Anthropic Claude 3 models.</p>\n         </note>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#StartAsyncInvoke": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.bedrockruntime#StartAsyncInvokeRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.bedrockruntime#StartAsyncInvokeResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.bedrockruntime#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ServiceUnavailableException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Starts an asynchronous invocation.</p>\n         <p>This operation requires permission for the <code>bedrock:InvokeModel</code> action.</p>\n         <important>\n            <p>To deny all inference access to resources that you specify in the modelId field, you\n         need to deny access to the <code>bedrock:InvokeModel</code> and\n            <code>bedrock:InvokeModelWithResponseStream</code> actions. Doing this also denies\n         access to the resource through the Converse API actions (<a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html\">Converse</a> and <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ConverseStream.html\">ConverseStream</a>). For more information see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/security_iam_id-based-policy-examples.html#security_iam_id-based-policy-examples-deny-inference\">Deny access for inference on specific models</a>.\n            </p>\n         </important>",
+                "smithy.api#http": {
+                    "code": 200,
+                    "method": "POST",
+                    "uri": "/async-invoke"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#StartAsyncInvokeRequest": {
+            "type": "structure",
+            "members": {
+                "clientRequestToken": {
+                    "target": "com.amazonaws.bedrockruntime#AsyncInvokeIdempotencyToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specify idempotency token to ensure that requests are not duplicated.</p>",
+                        "smithy.api#idempotencyToken": {}
+                    }
+                },
+                "modelId": {
+                    "target": "com.amazonaws.bedrockruntime#AsyncInvokeIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The model to invoke.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "modelInput": {
+                    "target": "com.amazonaws.bedrockruntime#ModelInputPayload",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Input to send to the model.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "outputDataConfig": {
+                    "target": "com.amazonaws.bedrockruntime#AsyncInvokeOutputDataConfig",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Where to store the output.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.bedrockruntime#TagList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Tags to apply to the invocation.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#StartAsyncInvokeResponse": {
+            "type": "structure",
+            "members": {
+                "invocationArn": {
+                    "target": "com.amazonaws.bedrockruntime#InvocationArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the invocation.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#StatusCode": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 100,
+                    "max": 599
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#StopReason": {
+            "type": "enum",
+            "members": {
+                "END_TURN": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "end_turn"
+                    }
+                },
+                "TOOL_USE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "tool_use"
+                    }
+                },
+                "MAX_TOKENS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "max_tokens"
+                    }
+                },
+                "STOP_SEQUENCE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "stop_sequence"
+                    }
+                },
+                "GUARDRAIL_INTERVENED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "guardrail_intervened"
+                    }
+                },
+                "CONTENT_FILTERED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "content_filtered"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#SystemContentBlock": {
+            "type": "union",
+            "members": {
+                "text": {
+                    "target": "com.amazonaws.bedrockruntime#NonEmptyString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A system prompt for the model. </p>"
+                    }
+                },
+                "guardContent": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailConverseContentBlock",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A content block to assess with the guardrail. Use with the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html\">Converse</a> or <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ConverseStream.html\">ConverseStream</a> API operations. </p>\n         <p>For more information, see <i>Use a guardrail with the Converse\n            API</i> in the <i>Amazon Bedrock User Guide</i>.</p>"
+                    }
+                },
+                "cachePoint": {
+                    "target": "com.amazonaws.bedrockruntime#CachePointBlock",
+                    "traits": {
+                        "smithy.api#documentation": "<p>CachePoint to include in the system prompt.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A system content block.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#SystemContentBlocks": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.bedrockruntime#SystemContentBlock"
+            }
+        },
+        "com.amazonaws.bedrockruntime#Tag": {
+            "type": "structure",
+            "members": {
+                "key": {
+                    "target": "com.amazonaws.bedrockruntime#TagKey",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The tag's key.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "value": {
+                    "target": "com.amazonaws.bedrockruntime#TagValue",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The tag's value.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A tag.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#TagKey": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 128
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9\\s._:/=+@-]*$"
+            }
+        },
+        "com.amazonaws.bedrockruntime#TagList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.bedrockruntime#Tag"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 200
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#TagValue": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 256
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9\\s._:/=+@-]*$"
+            }
+        },
+        "com.amazonaws.bedrockruntime#TextCharactersGuarded": {
+            "type": "integer"
+        },
+        "com.amazonaws.bedrockruntime#TextCharactersTotal": {
+            "type": "integer"
+        },
+        "com.amazonaws.bedrockruntime#ThrottlingException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.bedrockruntime#NonBlankString"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Your request was denied due to exceeding the account quotas for <i>Amazon Bedrock</i>. For\n         troubleshooting this error, see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/troubleshooting-api-error-codes.html#ts-throttling-exception\">ThrottlingException</a> in the Amazon Bedrock User Guide</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 429
+            }
+        },
+        "com.amazonaws.bedrockruntime#Timestamp": {
+            "type": "timestamp",
+            "traits": {
+                "smithy.api#timestampFormat": "date-time"
+            }
+        },
+        "com.amazonaws.bedrockruntime#TokenUsage": {
+            "type": "structure",
+            "members": {
+                "inputTokens": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of tokens sent in the request to the model.</p>",
+                        "smithy.api#range": {
+                            "min": 0
+                        },
+                        "smithy.api#required": {}
+                    }
+                },
+                "outputTokens": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of tokens that the model generated for the request.</p>",
+                        "smithy.api#range": {
+                            "min": 0
+                        },
+                        "smithy.api#required": {}
+                    }
+                },
+                "totalTokens": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The total of input tokens and tokens generated by the model.</p>",
+                        "smithy.api#range": {
+                            "min": 0
+                        },
+                        "smithy.api#required": {}
+                    }
+                },
+                "cacheReadInputTokens": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of input tokens read from the cache for the request.</p>",
+                        "smithy.api#range": {
+                            "min": 0
+                        }
+                    }
+                },
+                "cacheWriteInputTokens": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of input tokens written to the cache for the request.</p>",
+                        "smithy.api#range": {
+                            "min": 0
+                        }
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The tokens used in a message API inference call. </p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#Tool": {
+            "type": "union",
+            "members": {
+                "toolSpec": {
+                    "target": "com.amazonaws.bedrockruntime#ToolSpecification",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The specfication for the tool.</p>"
+                    }
+                },
+                "cachePoint": {
+                    "target": "com.amazonaws.bedrockruntime#CachePointBlock",
+                    "traits": {
+                        "smithy.api#documentation": "<p>CachePoint to include in the tool configuration.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about a tool that you can use with the Converse API. For more information, see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/tool-use.html\">Tool use (function calling)</a> in the Amazon Bedrock User Guide.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#ToolChoice": {
+            "type": "union",
+            "members": {
+                "auto": {
+                    "target": "com.amazonaws.bedrockruntime#AutoToolChoice",
+                    "traits": {
+                        "smithy.api#documentation": "<p>(Default). The Model automatically decides if a tool should be called or whether to generate text instead. </p>"
+                    }
+                },
+                "any": {
+                    "target": "com.amazonaws.bedrockruntime#AnyToolChoice",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The model must request at least one tool (no text is generated).</p>"
+                    }
+                },
+                "tool": {
+                    "target": "com.amazonaws.bedrockruntime#SpecificToolChoice",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Model must request the specified tool.  Only supported by Anthropic Claude 3 models. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Determines which tools the model should request in a call to <code>Converse</code> or <code>ConverseStream</code>.\n         <code>ToolChoice</code> is only supported by\n      Anthropic Claude 3 models and by Mistral AI Mistral Large.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#ToolConfiguration": {
+            "type": "structure",
+            "members": {
+                "tools": {
+                    "target": "com.amazonaws.bedrockruntime#Tools",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An array of tools that you want to pass to a model.</p>",
+                        "smithy.api#length": {
+                            "min": 1
+                        },
+                        "smithy.api#required": {}
+                    }
+                },
+                "toolChoice": {
+                    "target": "com.amazonaws.bedrockruntime#ToolChoice",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If supported by model, forces the model to request a tool.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration information for the tools that you pass to a model. For more information, see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/tool-use.html\">Tool use (function calling)</a> in the Amazon Bedrock User Guide.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#ToolInputSchema": {
+            "type": "union",
+            "members": {
+                "json": {
+                    "target": "smithy.api#Document",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The JSON schema for the tool. For more information, see <a href=\"https://json-schema.org/understanding-json-schema/reference\">JSON Schema Reference</a>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The schema for the tool. The top level schema type must be <code>object</code>. </p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#ToolName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 64
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9_-]+$"
+            }
+        },
+        "com.amazonaws.bedrockruntime#ToolResultBlock": {
+            "type": "structure",
+            "members": {
+                "toolUseId": {
+                    "target": "com.amazonaws.bedrockruntime#ToolUseId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the tool request that this is the result for.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "content": {
+                    "target": "com.amazonaws.bedrockruntime#ToolResultContentBlocks",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The content for tool result content block.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.bedrockruntime#ToolResultStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status for the tool result content block.</p>\n         <note>\n            <p>This field is only supported Anthropic Claude 3 models.</p>\n         </note>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A tool result block that contains the results for a tool request that\n      the model previously made.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#ToolResultContentBlock": {
+            "type": "union",
+            "members": {
+                "json": {
+                    "target": "smithy.api#Document",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A tool result that is JSON format data.</p>"
+                    }
+                },
+                "text": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A tool result that is text.</p>"
+                    }
+                },
+                "image": {
+                    "target": "com.amazonaws.bedrockruntime#ImageBlock",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A tool result that is an image.</p>\n         <note>\n            <p>This field is only supported by Anthropic Claude 3 models.</p>\n         </note>"
+                    }
+                },
+                "document": {
+                    "target": "com.amazonaws.bedrockruntime#DocumentBlock",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A tool result that is a document.</p>"
+                    }
+                },
+                "video": {
+                    "target": "com.amazonaws.bedrockruntime#VideoBlock",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A tool result that is video.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The tool result content block.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#ToolResultContentBlocks": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.bedrockruntime#ToolResultContentBlock"
+            }
+        },
+        "com.amazonaws.bedrockruntime#ToolResultStatus": {
+            "type": "enum",
+            "members": {
+                "SUCCESS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "success"
+                    }
+                },
+                "ERROR": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "error"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#ToolSpecification": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "com.amazonaws.bedrockruntime#ToolName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name for the tool.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.bedrockruntime#NonEmptyString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description for the tool.</p>"
+                    }
+                },
+                "inputSchema": {
+                    "target": "com.amazonaws.bedrockruntime#ToolInputSchema",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The input schema for the tool in JSON format.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The specification for the tool.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#ToolUseBlock": {
+            "type": "structure",
+            "members": {
+                "toolUseId": {
+                    "target": "com.amazonaws.bedrockruntime#ToolUseId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID for the tool request.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.bedrockruntime#ToolName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the tool that the model wants to use.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "input": {
+                    "target": "smithy.api#Document",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The input to pass to the tool. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A tool use content block. Contains information about a tool that the model\n      is requesting be run., The model uses the result from the tool to generate a response. </p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#ToolUseBlockDelta": {
+            "type": "structure",
+            "members": {
+                "input": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The input for a requested tool.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The delta for a tool use block.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#ToolUseBlockStart": {
+            "type": "structure",
+            "members": {
+                "toolUseId": {
+                    "target": "com.amazonaws.bedrockruntime#ToolUseId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID for the tool request.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.bedrockruntime#ToolName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the tool that the model is requesting to use.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The start of a tool use block.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#ToolUseId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 64
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9_-]+$"
+            }
+        },
+        "com.amazonaws.bedrockruntime#Tools": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.bedrockruntime#Tool"
+            }
+        },
+        "com.amazonaws.bedrockruntime#Trace": {
+            "type": "enum",
+            "members": {
+                "ENABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ENABLED"
+                    }
+                },
+                "DISABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DISABLED"
+                    }
+                },
+                "ENABLED_FULL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ENABLED_FULL"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#ValidationException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.bedrockruntime#NonBlankString"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The input fails to satisfy the constraints specified by <i>Amazon Bedrock</i>. For troubleshooting this error, \n         see <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/troubleshooting-api-error-codes.html#ts-validation-error\">ValidationError</a> in the Amazon Bedrock User Guide</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.bedrockruntime#VideoBlock": {
+            "type": "structure",
+            "members": {
+                "format": {
+                    "target": "com.amazonaws.bedrockruntime#VideoFormat",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The block's format.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "source": {
+                    "target": "com.amazonaws.bedrockruntime#VideoSource",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The block's source.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A video block.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#VideoFormat": {
+            "type": "enum",
+            "members": {
+                "MKV": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "mkv"
+                    }
+                },
+                "MOV": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "mov"
+                    }
+                },
+                "MP4": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "mp4"
+                    }
+                },
+                "WEBM": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "webm"
+                    }
+                },
+                "FLV": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "flv"
+                    }
+                },
+                "MPEG": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "mpeg"
+                    }
+                },
+                "MPG": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "mpg"
+                    }
+                },
+                "WMV": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "wmv"
+                    }
+                },
+                "THREE_GP": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "three_gp"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#VideoSource": {
+            "type": "union",
+            "members": {
+                "bytes": {
+                    "target": "smithy.api#Blob",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Video content encoded in base64.</p>",
+                        "smithy.api#length": {
+                            "min": 1
+                        }
+                    }
+                },
+                "s3Location": {
+                    "target": "com.amazonaws.bedrockruntime#S3Location",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The location of a video object in an S3 bucket.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A video source. You can upload a smaller video as a base64-encoded string as\n    long as the encoded file is less than 25MB. You can also transfer videos up to 1GB in size\n    from an S3 bucket.</p>"
+            }
+        }
+    }
+}


### PR DESCRIPTION
*Description of changes:*
This includes the model for the existing `bedrock-runtime` client and space for definitions of future clients. The full list of AWS service models can be found in https://github.com/aws/api-models-aws/tree/main/models. This project will maintain a snapshot of the model at time of release, updated as new clients are published.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
