### PR TITLE
Add reference to ContainerCredentialsResolver in the dev guide

### DIFF
--- a/dev-guide/credential-providers.md
+++ b/dev-guide/credential-providers.md
@@ -6,6 +6,9 @@ For guided options for getting started on AWS authentication for your project, s
 
 ## Credentials identity resolvers provided by the experimental Amazon Bedrock Runtime client for Python<a name="credproviders-available-credential-providers"></a>
 
+`ContainerCredentialsResolver`
+Obtains credentials from a container credential service such as the one provided with Amazon Elastic Container Service (Amazon ECS) and Amazon Elastic Kubernetes Service (Amazon EKS).
+
 `EnvironmentCredentialsResolver`  
 Resolves credentials found in the environment variables `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN`.
 


### PR DESCRIPTION
*Description of changes:*
Adding a quick note about [`ContainerCredentialsResolver`](https://github.com/smithy-lang/smithy-python/blob/3c057466696e78e225b42838090ab8eaa8f5b26c/packages/smithy-aws-core/src/smithy_aws_core/credentials_resolvers/container.py#L103) added in smithy-aws-core 0.0.3.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
