### PR TITLE
Minor Improvements to `aws-sdk`

### DIFF
--- a/clients/aws-sdk/pyproject.toml
+++ b/clients/aws-sdk/pyproject.toml
@@ -21,11 +21,9 @@ classifiers = [
 dependencies = []
 
 [project.optional-dependencies]
+bedrock_runtime = ["aws_sdk_bedrock_runtime==0.0.2"]
 all = [
-    "aws_sdk_bedrock_runtime",
-]
-bedrock_runtime = [
-    "aws_sdk_bedrock_runtime",
+    "aws_sdk[bedrock_runtime]",
 ]
 
 [build-system]

--- a/clients/aws-sdk/pyproject.toml
+++ b/clients/aws-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aws-sdk"
-version = "0.0.1"
+dynamic = ["version"]
 description = "Meta-package containing all AWS service clients."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -29,6 +29,9 @@ all = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+path = "src/aws_sdk/__init__.py"
 
 [tool.ruff]
 src = ["src"]

--- a/clients/aws-sdk/src/aws_sdk/__init__.py
+++ b/clients/aws-sdk/src/aws_sdk/__init__.py
@@ -1,4 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+import importlib.metadata
+
+__version__: str = importlib.metadata.version(__name__)
 
 # TODO: Consider adding relative imports for services from the top level namespace?

--- a/clients/aws-sdk/src/aws_sdk/__init__.py
+++ b/clients/aws-sdk/src/aws_sdk/__init__.py
@@ -1,7 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-import importlib.metadata
+__version__ = "0.0.1"
 
-__version__: str = importlib.metadata.version(__name__)
 
 # TODO: Consider adding relative imports for services from the top level namespace?


### PR DESCRIPTION
This PR adds the following minor improvements to the meta `aws-sdk` package. This aligns us with the planned approach for future automation:
- Add a strict dependency on the latest version of `aws_sdk_bedrock_runtime`. This will be the pattern used going forward.
- Reuse service extras in `all` to prevent us from having to maintain duplicate pins in the future. 
- Adds the `__version__` attribute for convenience and easier debugging.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
