### PR TITLE
Update integration tests to use the latest Amazon Nova 2 models

### DIFF
--- a/clients/aws-sdk-bedrock-runtime/tests/integration/__init__.py
+++ b/clients/aws-sdk-bedrock-runtime/tests/integration/__init__.py
@@ -9,8 +9,8 @@ from smithy_aws_core.identity import EnvironmentCredentialsResolver
 from aws_sdk_bedrock_runtime.client import BedrockRuntimeClient
 from aws_sdk_bedrock_runtime.config import Config
 
-MODEL_ID = "amazon.titan-text-express-v1"
-BIDIRECTIONAL_MODEL_ID = "amazon.nova-sonic-v1:0"
+MODEL_ID = "global.amazon.nova-2-lite-v1:0"
+BIDIRECTIONAL_MODEL_ID = "amazon.nova-2-sonic-v1:0"
 MESSAGE = "Who created the Python programming language?"
 AUDIO_FILE = Path(__file__).parent / "assets" / "test.pcm"
 


### PR DESCRIPTION
## Summary

The existing integration tests for `aws-sdk-bedrock-runtime` use the `amazon.titan-text-express-v1` foundational model for non-bidirectional-streaming tests. This has recently started throwing the following errors:

```
smithy_core.exceptions.RetryError: Error is not retryable: This model version has reached the end of its life. Please refer to the AWS documentation for more details.
```

This PR makes the following updates:
- `amazon.titan-text-express-v1` --> `global.amazon.nova-2-lite-v1:0`
  -  Addresses the exception mentioned above.
- `amazon.nova-sonic-v1:0` --> `amazon.nova-2-sonic-v1:0`
  - Proactively updating to prevent a similar exception when nova sonic v1 is deprecated in the future.

## Testing
- Copy AWS credentials to the environment
- Change into the aws-sdk-bedrock-runtime directory
  - `cd clients/aws-sdk-bedrock-runtime`
- Create and activate Python 3.12 virtual environment
  - `uv venv -p 3.12 && . .venv/bin/activate`
- Install `aws-sdk-bedrock-runtime` and test dependencies
  - `uv pip install . --group test`
- Run integration tests
  - `pytest tests/integration`

Output:
```
(aws-sdk-bedrock-runtime) $ pytest tests/integration
============================= test session starts =============================
platform darwin -- Python 3.12.12, pytest-7.4.4, pluggy-1.6.0
rootdir: /Users/gytndd/dev/GitHub/aws-sdk-python/clients/aws-sdk-bedrock-runtime
configfile: pyproject.toml
plugins: asyncio-0.20.3
asyncio: mode=Mode.AUTO
collected 3 items                                                             

tests/integration/test_bidirectional_streaming.py .                     [ 33%]
tests/integration/test_non_streaming.py .                               [ 66%]
tests/integration/test_output_streaming.py .                            [100%]

============================== warnings summary ===============================
tests/integration/test_non_streaming.py::test_converse
tests/integration/test_output_streaming.py::test_converse_stream
  /Users/gytndd/dev/GitHub/aws-sdk-python/clients/aws-sdk-bedrock-runtime/.venv/lib/python3.12/site-packages/aws_sdk_signers/signers.py:794: AWSSDKWarning: Payload signing is enabled. This may result in decreased performance for large request bodies.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================= 3 passed, 2 warnings in 15.07s ========================
```
---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
