### PR TITLE
Release: aws-sdk-python 0.3.0

### DIFF
--- a/clients/aws-sdk-python/src/aws_sdk_python/__init__.py
+++ b/clients/aws-sdk-python/src/aws_sdk_python/__init__.py
@@ -1,6 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 
 # TODO: Consider adding relative imports for services from the top level namespace?


### PR DESCRIPTION
This PR is dependent on #40, #41, and #42. Once those are merged and released, we can rebase this to do the final `aws-sdk-python` metapackage release.