### PR TITLE
Add API changelog check workflow

### DIFF
--- a/.github/workflows/api-changelog-check.yml
+++ b/.github/workflows/api-changelog-check.yml
@@ -1,0 +1,67 @@
+name: API Changelog Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    paths:
+      - 'codegen/aws-models/**'
+
+permissions:
+  contents: read
+
+jobs:
+  check-changelog:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changelog') }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+        with:
+          fetch-depth: 0
+
+      - name: Get changed model files
+        id: changed-models
+        run: |
+          changed_models=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- 'codegen/aws-models/*.json' | xargs -I {} basename {} .json)
+          echo "models<<EOF" >> $GITHUB_OUTPUT
+          echo "$changed_models" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Check for changelog entries
+        run: |
+          missing_changelogs=""
+
+          while IFS= read -r service; do
+            [ -z "$service" ] && continue
+
+            changelog_dir="clients/aws-sdk-${service}/.changes/next-release"
+
+            if [ ! -d "$changelog_dir" ]; then
+              missing_changelogs="${missing_changelogs}\n  - ${service} (directory does not exist: ${changelog_dir})"
+              continue
+            fi
+
+            # Check for valid changelog JSON files with required fields
+            valid_entry_found=false
+            for file in "$changelog_dir"/*.json; do
+              [ -e "$file" ] || continue
+              if jq -e '.type == "api-change" and .description' "$file" > /dev/null 2>&1; then
+                valid_entry_found=true
+                break
+              fi
+            done
+
+            if [ "$valid_entry_found" = false ]; then
+              missing_changelogs="${missing_changelogs}\n  - ${service} (no valid changelog entry in ${changelog_dir})"
+            fi
+          done <<< "${{ steps.changed-models.outputs.models }}"
+
+          if [ -n "$missing_changelogs" ]; then
+            printf "::error::Missing changelog entries for the following services:%b\n" "$missing_changelogs"
+            echo ""
+            echo "Please add a changelog entry in clients/aws-sdk-<service>/.changes/next-release/ for each modified model."
+            echo "Entry must be a JSON file with 'type: \"api-change\"' and 'description' fields."
+            exit 1
+          fi
+
+          echo "All modified models have corresponding changelog entries."

--- a/.github/workflows/api-changelog-check.yml
+++ b/.github/workflows/api-changelog-check.yml
@@ -18,11 +18,12 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Get changed model files
         id: changed-models
         run: |
-          changed_models=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- 'codegen/aws-models/*.json' | xargs -I {} basename {} .json)
+          changed_models=$(git diff --name-only origin/${GITHUB_BASE_REF}...HEAD -- 'codegen/aws-models/*.json' | xargs -I {} basename {} .json)
           echo "models<<EOF" >> $GITHUB_OUTPUT
           echo "$changed_models" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
@@ -54,7 +55,7 @@ jobs:
             if [ "$valid_entry_found" = false ]; then
               missing_changelogs="${missing_changelogs}\n  - ${service} (no valid changelog entry in ${changelog_dir})"
             fi
-          done <<< "${{ steps.changed-models.outputs.models }}"
+          done <<< "${STEPS_CHANGED_MODELS_OUTPUTS_MODELS}"
 
           if [ -n "$missing_changelogs" ]; then
             printf "::error::Missing changelog entries for the following services:%b\n" "$missing_changelogs"
@@ -65,3 +66,5 @@ jobs:
           fi
 
           echo "All modified models have corresponding changelog entries."
+        env:
+          STEPS_CHANGED_MODELS_OUTPUTS_MODELS: ${{ steps.changed-models.outputs.models }}


### PR DESCRIPTION
## Summary

Add a GitHub Actions workflow to ensure changelog entries are added when manually updating AWS models. When a PR modifies files in `codegen/aws-models/`, this workflow verifies that a corresponding changelog entry exists in `clients/aws-sdk-<service>/.changes/next-release/`.

## Workflow Behavior

| Trigger                               | Action                            |
|---------------------------------------|-----------------------------------|
| PR `modifies codegen/aws-models/*.json` | Checks for valid changelog entry  |
| `skip-changelog` label present          | Skips the check                   |
| Label added/removed                   | Re-runs to evaluate current state |

## Validation Requirements

A valid changelog entry must:
- Be a JSON file in clients/aws-sdk-<service>/.changes/next-release/
- Contain `"type": "api-change"` and a `"description"` field

## Test plan

- [x] Open a PR that modifies a model file without a changelog entry → check fails
- [x] Add a valid changelog entry → check passes
- [x] Add skip-changelog label to a failing PR → check skips
- [x] Remove skip-changelog label → check re-runs and validates

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
