### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ venv
 # Caches
 __pycache__/
 .ruff_cache/
+.pytest_cache/
 
 # Dependency lock file for uv
 uv.lock
+
+# Distribution / packaging
+dist/


### PR DESCRIPTION
## Summary

This will allow us to more easily ignore files in the `.pytest_cache/` and `dist/` directories when copying over code generated clients that have been build and tested.

Example command:

```
rsync -av --delete --exclude-from <path>/.gitignore
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
