### PR TITLE
Pre-Release: Update bedrock-runtime model and backfill changelog entries

### DIFF
--- a/clients/aws-sdk-bedrock-runtime/.changes/next-release/aws-sdk-bedrock-runtime-api-change-12f9965268834a989f712d2e197da205.json
+++ b/clients/aws-sdk-bedrock-runtime/.changes/next-release/aws-sdk-bedrock-runtime-api-change-12f9965268834a989f712d2e197da205.json
@@ -1,0 +1,4 @@
+{
+  "type": "api-change",
+  "description": "Added support for extended prompt caching with one hour TTL."
+}

--- a/clients/aws-sdk-bedrock-runtime/.changes/next-release/aws-sdk-bedrock-runtime-api-change-435cebed99a34da0adfb5cb36a386d9b.json
+++ b/clients/aws-sdk-bedrock-runtime/.changes/next-release/aws-sdk-bedrock-runtime-api-change-435cebed99a34da0adfb5cb36a386d9b.json
@@ -1,0 +1,4 @@
+{
+  "type": "api-change",
+  "description": "Added support for structured outputs to Converse and ConverseStream APIs."
+}

--- a/clients/aws-sdk-bedrock-runtime/.changes/next-release/aws-sdk-bedrock-runtime-enhancement-ba0310435c33445295009674f239001b.json
+++ b/clients/aws-sdk-bedrock-runtime/.changes/next-release/aws-sdk-bedrock-runtime-enhancement-ba0310435c33445295009674f239001b.json
@@ -1,0 +1,4 @@
+{
+  "type": "enhancement",
+  "description": "Update package docstrings from Sphinx style to Google style for improved readability and consistency with Python community standards. ([#48](https://github.com/awslabs/aws-sdk-python/pull/48)"
+}

--- a/clients/aws-sdk-bedrock-runtime/.changes/next-release/aws-sdk-bedrock-runtime-enhancement-ba0310435c33445295009674f239001b.json
+++ b/clients/aws-sdk-bedrock-runtime/.changes/next-release/aws-sdk-bedrock-runtime-enhancement-ba0310435c33445295009674f239001b.json
@@ -1,4 +1,4 @@
 {
   "type": "enhancement",
-  "description": "Update package docstrings from Sphinx style to Google style for improved readability and consistency with Python community standards. ([#48](https://github.com/awslabs/aws-sdk-python/pull/48)"
+  "description": "Update package docstrings from Sphinx style to Google style for improved readability and consistency with Python community standards. ([#48](https://github.com/awslabs/aws-sdk-python/pull/48))"
 }

--- a/clients/aws-sdk-python/.changes/0.0.1.json
+++ b/clients/aws-sdk-python/.changes/0.0.1.json
@@ -1,0 +1,8 @@
+{
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Initial release for aws-sdk-python. Includes an optional dependency for bedrock_runtime."
+    }
+  ]
+}

--- a/clients/aws-sdk-python/.changes/0.1.0.json
+++ b/clients/aws-sdk-python/.changes/0.1.0.json
@@ -1,0 +1,8 @@
+{
+  "changes": [
+    {
+      "type": "dependency",
+      "description": "Pin `bedrock_runtime` optional dependency group to `aws_sdk_bedrock_runtime==0.1.0`."
+    }
+  ]
+}

--- a/clients/aws-sdk-python/.changes/0.1.1.json
+++ b/clients/aws-sdk-python/.changes/0.1.1.json
@@ -1,0 +1,8 @@
+{
+  "changes": [
+    {
+      "type": "dependency",
+      "description": "Bump `aws-sdk-bedrock-runtime` from `==0.1.0` to `==0.1.1`."
+    }
+  ]
+}

--- a/clients/aws-sdk-python/.changes/0.1.2.json
+++ b/clients/aws-sdk-python/.changes/0.1.2.json
@@ -1,0 +1,8 @@
+{
+  "changes": [
+    {
+      "type": "dependency",
+      "description": "Add optional dependency on `aws-sdk-transcribe-streaming==0.1.0`."
+    }
+  ]
+}

--- a/clients/aws-sdk-python/.changes/0.2.0.json
+++ b/clients/aws-sdk-python/.changes/0.2.0.json
@@ -1,0 +1,16 @@
+{
+  "changes": [
+    {
+      "type": "dependency",
+      "description": "Bump `aws-sdk-transcribe-streaming` from `==0.1.0` to `==0.2.0`."
+    },
+    {
+      "type": "dependency",
+      "description": "Add optional dependency on `aws-sdk-sagemaker-runtime-http2==0.1.0`."
+    },
+    {
+      "type": "dependency",
+      "description": "Bump `aws-sdk-bedrock-runtime` from `==0.1.1` to `==0.2.0`."
+    }
+  ]
+}

--- a/clients/aws-sdk-python/.changes/0.3.0.json
+++ b/clients/aws-sdk-python/.changes/0.3.0.json
@@ -1,0 +1,16 @@
+{
+  "changes": [
+    {
+      "type": "dependency",
+      "description": "Bump `aws-sdk-sagemaker-runtime-http2` from `==0.1.0` to `==0.3.0`."
+    },
+    {
+      "type": "dependency",
+      "description": "Bump `aws-sdk-bedrock-runtime` from `==0.2.0` to `==0.3.0`."
+    },
+    {
+      "type": "dependency",
+      "description": "Bump `aws-sdk-transcribe-streaming` from `==0.2.0` to `==0.3.0`."
+    }
+  ]
+}

--- a/clients/aws-sdk-python/CHANGELOG.md
+++ b/clients/aws-sdk-python/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+## v0.3.0
+
+### Dependencies
+* Bump `aws-sdk-sagemaker-runtime-http2` from `==0.1.0` to `==0.3.0`.
+* Bump `aws-sdk-bedrock-runtime` from `==0.2.0` to `==0.3.0`.
+* Bump `aws-sdk-transcribe-streaming` from `==0.2.0` to `==0.3.0`.
+
+## v0.2.0
+
+### Dependencies
+* Bump `aws-sdk-transcribe-streaming` from `==0.1.0` to `==0.2.0`.
+* Add optional dependency on `aws-sdk-sagemaker-runtime-http2==0.1.0`.
+* Bump `aws-sdk-bedrock-runtime` from `==0.1.1` to `==0.2.0`.
+
+## v0.1.2
+
+### Dependencies
+* Add optional dependency on `aws-sdk-transcribe-streaming==0.1.0`.
+
+## v0.1.1
+
+### Dependencies
+* Bump `aws-sdk-bedrock-runtime` from `==0.1.0` to `==0.1.1`.
+
+## v0.1.0
+
+### Dependencies
+* Pin `bedrock_runtime` optional dependency group to `aws_sdk_bedrock_runtime==0.1.0`.
+
+## v0.0.1
+
+### Features
+* Initial release for aws-sdk-python. Includes an optional dependency for bedrock_runtime.

--- a/clients/aws-sdk-sagemaker-runtime-http2/.changes/next-release/aws-sdk-sagemaker-runtime-http2-enhancement-5857698a440c4354a68b20610d4117ed.json
+++ b/clients/aws-sdk-sagemaker-runtime-http2/.changes/next-release/aws-sdk-sagemaker-runtime-http2-enhancement-5857698a440c4354a68b20610d4117ed.json
@@ -1,0 +1,4 @@
+{
+  "type": "enhancement",
+  "description": "Update package docstrings from Sphinx style to Google style for improved readability and consistency with Python community standards. ([#48](https://github.com/awslabs/aws-sdk-python/pull/48)"
+}

--- a/clients/aws-sdk-sagemaker-runtime-http2/.changes/next-release/aws-sdk-sagemaker-runtime-http2-enhancement-5857698a440c4354a68b20610d4117ed.json
+++ b/clients/aws-sdk-sagemaker-runtime-http2/.changes/next-release/aws-sdk-sagemaker-runtime-http2-enhancement-5857698a440c4354a68b20610d4117ed.json
@@ -1,4 +1,4 @@
 {
   "type": "enhancement",
-  "description": "Update package docstrings from Sphinx style to Google style for improved readability and consistency with Python community standards. ([#48](https://github.com/awslabs/aws-sdk-python/pull/48)"
+  "description": "Update package docstrings from Sphinx style to Google style for improved readability and consistency with Python community standards. ([#48](https://github.com/awslabs/aws-sdk-python/pull/48))"
 }

--- a/clients/aws-sdk-transcribe-streaming/.changes/next-release/aws-sdk-transcribe-streaming-enhancement-794a4e99c7e7493195a0ed7f4d2f464e.json
+++ b/clients/aws-sdk-transcribe-streaming/.changes/next-release/aws-sdk-transcribe-streaming-enhancement-794a4e99c7e7493195a0ed7f4d2f464e.json
@@ -1,0 +1,4 @@
+{
+  "type": "enhancement",
+  "description": "Update package docstrings from Sphinx style to Google style for improved readability and consistency with Python community standards. ([#48](https://github.com/awslabs/aws-sdk-python/pull/48)"
+}

--- a/clients/aws-sdk-transcribe-streaming/.changes/next-release/aws-sdk-transcribe-streaming-enhancement-794a4e99c7e7493195a0ed7f4d2f464e.json
+++ b/clients/aws-sdk-transcribe-streaming/.changes/next-release/aws-sdk-transcribe-streaming-enhancement-794a4e99c7e7493195a0ed7f4d2f464e.json
@@ -1,4 +1,4 @@
 {
   "type": "enhancement",
-  "description": "Update package docstrings from Sphinx style to Google style for improved readability and consistency with Python community standards. ([#48](https://github.com/awslabs/aws-sdk-python/pull/48)"
+  "description": "Update package docstrings from Sphinx style to Google style for improved readability and consistency with Python community standards. ([#48](https://github.com/awslabs/aws-sdk-python/pull/48))"
 }

--- a/codegen/aws-models/bedrock-runtime.json
+++ b/codegen/aws-models/bedrock-runtime.json
@@ -1270,6 +1270,40 @@
                 "smithy.api#sensitive": {}
             }
         },
+        "com.amazonaws.bedrockruntime#CacheDetail": {
+            "type": "structure",
+            "members": {
+                "ttl": {
+                    "target": "com.amazonaws.bedrockruntime#CacheTTL",
+                    "traits": {
+                        "smithy.api#documentation": "<p>TTL duration for these cached tokens</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "inputTokens": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Number of tokens written to cache with this TTL (cache creation tokens)</p>",
+                        "smithy.api#range": {
+                            "min": 0
+                        },
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Cache creation metrics for a specific TTL duration</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#CacheDetailsList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.bedrockruntime#CacheDetail"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>List of cache details by TTL</p>"
+            }
+        },
         "com.amazonaws.bedrockruntime#CachePointBlock": {
             "type": "structure",
             "members": {
@@ -1278,6 +1312,12 @@
                     "traits": {
                         "smithy.api#documentation": "<p>Specifies the type of cache point within the CachePointBlock.</p>",
                         "smithy.api#required": {}
+                    }
+                },
+                "ttl": {
+                    "target": "com.amazonaws.bedrockruntime#CacheTTL",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Optional TTL duration for cache entries. When specified, enables extended TTL caching with the specified duration. When omitted, uses <code>type</code> value for caching behavior.</p>"
                     }
                 }
             },
@@ -1294,6 +1334,26 @@
                         "smithy.api#enumValue": "default"
                     }
                 }
+            }
+        },
+        "com.amazonaws.bedrockruntime#CacheTTL": {
+            "type": "enum",
+            "members": {
+                "FIVE_MINUTES": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "5m"
+                    }
+                },
+                "ONE_HOUR": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "1h"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Time-to-live duration for ephemeral cache entries</p>"
             }
         },
         "com.amazonaws.bedrockruntime#Citation": {
@@ -1908,6 +1968,12 @@
                     "traits": {
                         "smithy.api#documentation": "<p>Specifies the processing tier configuration used for serving the request.</p>"
                     }
+                },
+                "outputConfig": {
+                    "target": "com.amazonaws.bedrockruntime#OutputConfig",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Output configuration for a model response.</p>"
+                    }
                 }
             },
             "traits": {
@@ -2228,6 +2294,12 @@
                     "target": "com.amazonaws.bedrockruntime#ServiceTier",
                     "traits": {
                         "smithy.api#documentation": "<p>Specifies the processing tier configuration used for serving the request.</p>"
+                    }
+                },
+                "outputConfig": {
+                    "target": "com.amazonaws.bedrockruntime#OutputConfig",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Output configuration for a model response.</p>"
                     }
                 }
             },
@@ -5650,6 +5722,33 @@
                 "smithy.api#pattern": "^(arn:aws(-[^:]+)?:bedrock:[a-z0-9-]{1,20}::foundation-model/[a-z0-9-]{1,63}[.]{1}[a-z0-9-]{1,63}([a-z0-9-]{1,63}[.]){0,2}[a-z0-9-]{1,63}([:][a-z0-9-]{1,63}){0,2})|(arn:aws(|-us-gov|-cn|-iso|-iso-b):bedrock:(|[0-9a-z-]{1,20}):(|[0-9]{12}):inference-profile/[a-zA-Z0-9-:.]+)$"
             }
         },
+        "com.amazonaws.bedrockruntime#JsonSchemaDefinition": {
+            "type": "structure",
+            "members": {
+                "schema": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The JSON schema to constrain the model's output. For more information, see <a href=\"https://json-schema.org/understanding-json-schema/reference\">JSON Schema Reference</a>. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "name": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The name of the JSON schema. </p>"
+                    }
+                },
+                "description": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p> A description of the JSON schema. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p> JSON schema structured output format options. </p>"
+            }
+        },
         "com.amazonaws.bedrockruntime#KmsKeyId": {
             "type": "string",
             "traits": {
@@ -5968,6 +6067,71 @@
                 "smithy.api#range": {
                     "min": 0
                 }
+            }
+        },
+        "com.amazonaws.bedrockruntime#OutputConfig": {
+            "type": "structure",
+            "members": {
+                "textFormat": {
+                    "target": "com.amazonaws.bedrockruntime#OutputFormat",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Structured output parameters to control the model's text response. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Output configuration for a model response in a call to <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html\">Converse</a> or <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ConverseStream.html\">ConverseStream</a>.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#OutputFormat": {
+            "type": "structure",
+            "members": {
+                "type": {
+                    "target": "com.amazonaws.bedrockruntime#OutputFormatType",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The type of structured output format. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "structure": {
+                    "target": "com.amazonaws.bedrockruntime#OutputFormatStructure",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The structure that the model's output must adhere to. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p> Structured output parameters to control the model's response. </p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#OutputFormatStructure": {
+            "type": "union",
+            "members": {
+                "jsonSchema": {
+                    "target": "com.amazonaws.bedrockruntime#JsonSchemaDefinition",
+                    "traits": {
+                        "smithy.api#documentation": "<p> A JSON schema structure that the model's output must adhere to. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p> The structure that the model's output must adhere to. </p>",
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#OutputFormatType": {
+            "type": "enum",
+            "members": {
+                "JSON_SCHEMA": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "json_schema"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p> The type of structured output format. Available options are: json_schema. </p>"
             }
         },
         "com.amazonaws.bedrockruntime#PaginationToken": {
@@ -6820,6 +6984,12 @@
                             "min": 0
                         }
                     }
+                },
+                "cacheDetails": {
+                    "target": "com.amazonaws.bedrockruntime#CacheDetailsList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Detailed breakdown of cache writes by TTL. Empty if no cache creation occurred. Sorted by TTL duration (1h before 5m).</p>"
+                    }
                 }
             },
             "traits": {
@@ -7109,6 +7279,12 @@
                     "traits": {
                         "smithy.api#documentation": "<p>The input schema for the tool in JSON format.</p>",
                         "smithy.api#required": {}
+                    }
+                },
+                "strict": {
+                    "target": "smithy.api#Boolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Flag to enable structured output enforcement on a tool usage response.</p>"
                     }
                 }
             },


### PR DESCRIPTION
## Summary

This PR syncs our bedrock-runtime.json model with the latest version and adds the following API changelog entries:
> Note: These come from the upstream bedrock runtime service release notes
- Added support for extended prompt caching with one hour TTL.
- Added support for structured outputs to Converse and ConverseStream APIs.

Additionally, this PR backfills changelog entries for https://github.com/awslabs/aws-sdk-python/pull/48 in each service package.

Lastly, I backfilled changelog entries for aws-sdk-python v0.0.1 through v0.3.0.


---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
