### PR TITLE
Increase bidirectional streaming test end-of-input delay

### DIFF
--- a/clients/aws-sdk-transcribe-streaming/tests/integration/test_bidirectional_streaming.py
+++ b/clients/aws-sdk-transcribe-streaming/tests/integration/test_bidirectional_streaming.py
@@ -53,7 +53,7 @@ async def _send_audio_chunks(
     await stream.input_stream.send(
         AudioStreamAudioEvent(value=AudioEvent(audio_chunk=b""))
     )
-    await asyncio.sleep(0.4)
+    await asyncio.sleep(1.2)
     await stream.input_stream.close()
 
 


### PR DESCRIPTION
## Summary

Increase the delay between sending the final empty audio frame and closing the input stream in the bidirectional streaming integration test. This is a temporary mitigation to reduce intermittent failures in our automation system while we work toward a more reliable long-term stream shutdown fix.

## Testing

Ran integ tests in a loop with different delays:

> Note: failure counts are for `BadRequestException: A complete signal was sent without the preceding empty frame.`
- delay=0.4 failures=9/100
- delay=1.0 failures=2/100
- delay=1.2 failures=0/100
  - Note I did see `AWS_IO_TLS_NEGOTIATION_TIMEOUT: Channel shutdown due to tls negotiation timeout`. however, these are not related to this issue. Most likely transient local/service networking issues. 

Related: https://github.com/awslabs/aws-sdk-python/issues/46

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
