### PR TITLE
Update service models for bedrock-runtime and transcribe-streaming

### DIFF
--- a/clients/aws-sdk-bedrock-runtime/.changes/next-release/aws-sdk-bedrock-runtime-api-change-799059f703a94e11939f38c730de853b.json
+++ b/clients/aws-sdk-bedrock-runtime/.changes/next-release/aws-sdk-bedrock-runtime-api-change-799059f703a94e11939f38c730de853b.json
@@ -1,0 +1,4 @@
+{
+  "type": "api-change",
+  "description": "Relax ToolUseId pattern to allow dots and colons"
+}

--- a/clients/aws-sdk-transcribe-streaming/.changes/next-release/aws-sdk-transcribe-streaming-api-change-a76516c6e27549fba1f6d956804a494d.json
+++ b/clients/aws-sdk-transcribe-streaming/.changes/next-release/aws-sdk-transcribe-streaming-api-change-a76516c6e27549fba1f6d956804a494d.json
@@ -1,0 +1,4 @@
+{
+  "type": "api-change",
+  "description": "AWS Transcribe Streaming now supports specifying a resumption window for the stream through the SessionResumeWindow parameter, allowing customers to reconnect to their streams for a longer duration beyond stream start time."
+}

--- a/codegen/aws-models/bedrock-runtime.json
+++ b/codegen/aws-models/bedrock-runtime.json
@@ -7377,7 +7377,7 @@
                     "min": 1,
                     "max": 64
                 },
-                "smithy.api#pattern": "^[a-zA-Z0-9_-]+$"
+                "smithy.api#pattern": "^[a-zA-Z0-9_.:-]+$"
             }
         },
         "com.amazonaws.bedrockruntime#ToolUseType": {

--- a/codegen/aws-models/transcribe-streaming.json
+++ b/codegen/aws-models/transcribe-streaming.json
@@ -2778,6 +2778,15 @@
                 "smithy.api#pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
             }
         },
+        "com.amazonaws.transcribestreaming#SessionResumeWindow": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 300
+                }
+            }
+        },
         "com.amazonaws.transcribestreaming#Specialty": {
             "type": "enum",
             "members": {
@@ -3668,7 +3677,7 @@
                 "PiiEntityTypes": {
                     "target": "com.amazonaws.transcribestreaming#PiiEntityTypes",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specify which types of personally identifiable information (PII) you want to redact in your \n      transcript. You can include as many types as you'd like, or you can select \n      <code>ALL</code>.</p>\n         <p>Values must be comma-separated and can include: <code>ADDRESS</code>, \n      <code>BANK_ACCOUNT_NUMBER</code>, <code>BANK_ROUTING</code>,\n      <code>CREDIT_DEBIT_CVV</code>, <code>CREDIT_DEBIT_EXPIRY</code>,\n      <code>CREDIT_DEBIT_NUMBER</code>, <code>EMAIL</code>, \n      <code>NAME</code>, <code>PHONE</code>, <code>PIN</code>, \n      <code>SSN</code>, or <code>ALL</code>.</p>\n         <p>Note that if you include <code>PiiEntityTypes</code> in your request, you must also include \n      <code>ContentIdentificationType</code> or <code>ContentRedactionType</code>.</p>\n         <p>If you include <code>ContentRedactionType</code> or \n      <code>ContentIdentificationType</code> in your request, but do not include \n      <code>PiiEntityTypes</code>, all PII is redacted or identified.</p>",
+                        "smithy.api#documentation": "<p>Specify which types of personally identifiable information (PII) you want to redact in your \n      transcript. You can include as many types as you'd like, or you can select \n      <code>ALL</code>.</p>\n         <p>Values must be comma-separated and can include: <code>ADDRESS</code>, \n      <code>BANK_ACCOUNT_NUMBER</code>, <code>BANK_ROUTING</code>,\n      <code>CREDIT_DEBIT_CVV</code>, <code>CREDIT_DEBIT_EXPIRY</code>,\n      <code>CREDIT_DEBIT_NUMBER</code>, <code>EMAIL</code>, \n      <code>NAME</code>, <code>PHONE</code>, <code>PIN</code>, \n      <code>SSN</code>, <code>AGE</code>, <code>DATE_TIME</code>,\n      <code>LICENSE_PLATE</code>, <code>PASSPORT_NUMBER</code>,\n      <code>PASSWORD</code>, <code>USERNAME</code>, <code>VEHICLE_IDENTIFICATION_NUMBER</code>, or <code>ALL</code>.</p>\n         <p>Note that if you include <code>PiiEntityTypes</code> in your request, you must also include \n      <code>ContentIdentificationType</code> or <code>ContentRedactionType</code>.</p>\n         <p>If you include <code>ContentRedactionType</code> or \n      <code>ContentIdentificationType</code> in your request, but do not include \n      <code>PiiEntityTypes</code>, all PII is redacted or identified.</p>",
                         "smithy.api#httpHeader": "x-amzn-transcribe-pii-entity-types"
                     }
                 },
@@ -3721,6 +3730,13 @@
                     "traits": {
                         "smithy.api#documentation": "<p>Specify the names of the custom vocabulary filters that you want to use when processing\n      your transcription. Note that vocabulary filter names are case sensitive.</p>\n         <p>If none of the languages of the specified custom vocabulary filters match the language identified\n      in your media, your job fails.</p>\n         <important>\n            <p>This parameter is only intended for use <b>with</b> \n        the <code>IdentifyLanguage</code> parameter. If you're <b>not</b> \n        including <code>IdentifyLanguage</code> in your request and want to use a custom vocabulary filter \n        with your transcription, use the <code>VocabularyFilterName</code> parameter instead.</p>\n         </important>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/vocabulary-filtering.html\">Using vocabulary filtering with unwanted \n      words</a>.</p>",
                         "smithy.api#httpHeader": "x-amzn-transcribe-vocabulary-filter-names"
+                    }
+                },
+                "SessionResumeWindow": {
+                    "target": "com.amazonaws.transcribestreaming#SessionResumeWindow",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specify the time window, in minutes, during which your transcription session can be resumed,\n       measured from the stream start time. This optional parameter accepts integer values from 1 to 300 (5 hours).</p>\n         <p> For example, if your stream starts at 1 PM and you specify a <code>SessionResumeWindow</code> of 30 minutes,\n      you can reconnect to the session as many times as you want until 1:30 PM. </p>",
+                        "smithy.api#httpHeader": "x-amzn-transcribe-session-resume-window"
                     }
                 }
             },
@@ -3902,6 +3918,13 @@
                     "traits": {
                         "smithy.api#documentation": "<p>Provides the names of the custom vocabulary filters that you specified in your\n      request.</p>",
                         "smithy.api#httpHeader": "x-amzn-transcribe-vocabulary-filter-names"
+                    }
+                },
+                "SessionResumeWindow": {
+                    "target": "com.amazonaws.transcribestreaming#SessionResumeWindow",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Provides the session resume window, in minutes, that you specified in your request.</p>",
+                        "smithy.api#httpHeader": "x-amzn-transcribe-session-resume-window"
                     }
                 }
             },


### PR DESCRIPTION
## Summary

This PR syncs our `bedrock-runtime.json` and `transcribe-streaming.json` Smithy models with the latest version and adds the following API changelog entries:

> [!NOTE]
> These changelog entry descriptions come from the upstream service release notes
- aws-sdk-bedrock-runtime: "Relax ToolUseId pattern to allow dots and colons"
- aws-sdk-transcribe-streaming: "AWS Transcribe Streaming now supports specifying a resumption window for the stream through the SessionResumeWindow parameter, allowing customers to reconnect to their streams for a longer duration beyond stream start time."

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
