### PR TITLE
Remove Transcribe stream close workarounds

### DIFF
--- a/clients/aws-sdk-transcribe-streaming/examples/simple_file.py
+++ b/clients/aws-sdk-transcribe-streaming/examples/simple_file.py
@@ -112,10 +112,6 @@ async def write_chunks(audio_stream: EventPublisher[AudioStream]):
             audio_stream, reader, BYTES_PER_SAMPLE, SAMPLE_RATE, CHANNEL_NUMS
         )
 
-    # Send an empty audio event to signal end of input
-    await audio_stream.send(AudioStreamAudioEvent(value=AudioEvent(audio_chunk=b"")))
-    # Small delay to ensure empty frame is sent before close
-    await asyncio.sleep(0.4)
     await audio_stream.close()
 
 

--- a/clients/aws-sdk-transcribe-streaming/tests/integration/test_bidirectional_streaming.py
+++ b/clients/aws-sdk-transcribe-streaming/tests/integration/test_bidirectional_streaming.py
@@ -49,11 +49,6 @@ async def _send_audio_chunks(
             wait_time = start_time + elapsed_audio_time - time.time()
             await asyncio.sleep(wait_time)
 
-    # Send an empty audio event to signal end of input
-    await stream.input_stream.send(
-        AudioStreamAudioEvent(value=AudioEvent(audio_chunk=b""))
-    )
-    await asyncio.sleep(1.2)
     await stream.input_stream.close()
 
 


### PR DESCRIPTION
> [!WARNING]
> This PR should be merged following https://github.com/smithy-lang/smithy-python/pull/692 and https://github.com/smithy-lang/smithy-python/pull/691

Related: https://github.com/awslabs/aws-sdk-python/issues/46

## Summary

Update examples to rely on event stream close to send the signed empty terminator frame, so the Transcribe example and integration test no longer need to send a manual empty audio event or sleep before closing the input stream.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
