### PR TITLE
Update services models to their latest version

### DIFF
--- a/clients/aws-sdk-bedrock-runtime/.changes/next-release/aws-sdk-bedrock-runtime-api-change-0d484147b83d43c3a7e8a1c984034017.json
+++ b/clients/aws-sdk-bedrock-runtime/.changes/next-release/aws-sdk-bedrock-runtime-api-change-0d484147b83d43c3a7e8a1c984034017.json
@@ -1,0 +1,4 @@
+{
+  "type": "api-change",
+  "description": "InvokeGuardrailChecks API evaluates prompts and responses against safety checks (content filters, prompt attacks, sensitive info) without creating guardrail resources. It's a detect-only API, returning numeric scores so you can build adaptive logic as per your application."
+}

--- a/clients/aws-sdk-bedrock-runtime/.changes/next-release/aws-sdk-bedrock-runtime-api-change-6b52a9dfad4a40b986640461b6fc742c.json
+++ b/clients/aws-sdk-bedrock-runtime/.changes/next-release/aws-sdk-bedrock-runtime-api-change-6b52a9dfad4a40b986640461b6fc742c.json
@@ -1,0 +1,4 @@
+{
+  "type": "api-change",
+  "description": "Supporting Request Metadata for Invoke Model and Invoke Model with Response Stream."
+}

--- a/clients/aws-sdk-bedrock-runtime/.changes/next-release/aws-sdk-bedrock-runtime-api-change-6b52a9dfad4a40b986640461b6fc742c.json
+++ b/clients/aws-sdk-bedrock-runtime/.changes/next-release/aws-sdk-bedrock-runtime-api-change-6b52a9dfad4a40b986640461b6fc742c.json
@@ -1,4 +1,4 @@
 {
   "type": "api-change",
-  "description": "Supporting Request Metadata for Invoke Model and Invoke Model with Response Stream."
+  "description": "Support Request Metadata for Invoke Model and Invoke Model with Response Stream."
 }

--- a/clients/aws-sdk-bedrock-runtime/.changes/next-release/aws-sdk-bedrock-runtime-api-change-76f58b21d5994aaf8fddddabe7ef3172.json
+++ b/clients/aws-sdk-bedrock-runtime/.changes/next-release/aws-sdk-bedrock-runtime-api-change-76f58b21d5994aaf8fddddabe7ef3172.json
@@ -1,0 +1,4 @@
+{
+  "type": "api-change",
+  "description": "Support system role in message."
+}

--- a/clients/aws-sdk-connecthealth/.changes/next-release/aws-sdk-connecthealth-api-change-c1d0e42331ac4fb0b64fa067200b3a23.json
+++ b/clients/aws-sdk-connecthealth/.changes/next-release/aws-sdk-connecthealth-api-change-c1d0e42331ac4fb0b64fa067200b3a23.json
@@ -1,0 +1,4 @@
+{
+  "type": "api-change",
+  "description": "Add support for MedicalScribeBinaryAudioEvent in the Medical Scribe streaming input. This new event type lets you send audio as a raw binary payload instead of a base64-encoded value"
+}

--- a/codegen/aws-models/bedrock-runtime.json
+++ b/codegen/aws-models/bedrock-runtime.json
@@ -3664,6 +3664,808 @@
                 "smithy.api#documentation": "<p>Indicates that the claims are definitively true and logically implied by the premises, with no possible alternative interpretations.</p>"
             }
         },
+        "com.amazonaws.bedrockruntime#GuardrailChecksConfig": {
+            "type": "structure",
+            "members": {
+                "contentFilter": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailChecksContentFilterConfig",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The content filter check configuration.</p>"
+                    }
+                },
+                "promptAttack": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailChecksPromptAttackConfig",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The prompt attack check configuration.</p>"
+                    }
+                },
+                "sensitiveInformation": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailChecksSensitiveInformationConfig",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The sensitive information check configuration.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The configuration for inline guardrail checks. Specify one or more check types to run against the messages.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailChecksContentBlock": {
+            "type": "union",
+            "members": {
+                "text": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailChecksTextContent",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The text content to evaluate.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A content block within a message to evaluate.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailChecksContentBlockList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.bedrockruntime#GuardrailChecksContentBlock"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A list of content blocks within a message.</p>",
+                "smithy.api#length": {
+                    "min": 1
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailChecksContentFilterCategory": {
+            "type": "enum",
+            "members": {
+                "VIOLENCE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "VIOLENCE"
+                    }
+                },
+                "HATE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "HATE"
+                    }
+                },
+                "SEXUAL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SEXUAL"
+                    }
+                },
+                "MISCONDUCT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MISCONDUCT"
+                    }
+                },
+                "INSULTS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "INSULTS"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The category for content filter evaluation.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailChecksContentFilterCategoryConfig": {
+            "type": "structure",
+            "members": {
+                "category": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailChecksContentFilterCategory",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The content filter category to evaluate.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The configuration for a single content filter category to evaluate.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailChecksContentFilterCategoryConfigList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.bedrockruntime#GuardrailChecksContentFilterCategoryConfig"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A list of content filter category configurations.</p>",
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 5
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailChecksContentFilterConfig": {
+            "type": "structure",
+            "members": {
+                "categories": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailChecksContentFilterCategoryConfigList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The content filter categories to evaluate.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The configuration for the content filter check, specifying which categories to evaluate.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailChecksContentFilterResult": {
+            "type": "structure",
+            "members": {
+                "results": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailChecksContentFilterResultList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The per-category content filter results.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The content filter check results.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailChecksContentFilterResultEntry": {
+            "type": "structure",
+            "members": {
+                "category": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailChecksContentFilterCategory",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The content filter category that was evaluated.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "severityScore": {
+                    "target": "smithy.api#Double",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The severity score for the category, ranging from 0.0 to 1.0. Higher values indicate greater severity.</p>",
+                        "smithy.api#range": {
+                            "min": 0.0,
+                            "max": 1.0
+                        },
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The evaluation result for a single content filter category.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailChecksContentFilterResultList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.bedrockruntime#GuardrailChecksContentFilterResultEntry"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A list of content filter evaluation results.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailChecksContentFilterUsage": {
+            "type": "structure",
+            "members": {
+                "textUnits": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of text units consumed by the content filter check.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The text unit usage for the content filter check.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailChecksMessage": {
+            "type": "structure",
+            "members": {
+                "role": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailChecksRole",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The role of the message sender.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "content": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailChecksContentBlockList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The content blocks for the message.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A message to evaluate against guardrail checks, containing a role and content blocks.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailChecksMessageList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.bedrockruntime#GuardrailChecksMessage"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A list of messages to evaluate.</p>",
+                "smithy.api#length": {
+                    "min": 1
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailChecksPromptAttackCategory": {
+            "type": "enum",
+            "members": {
+                "JAILBREAK": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "JAILBREAK"
+                    }
+                },
+                "PROMPT_INJECTION": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PROMPT_INJECTION"
+                    }
+                },
+                "PROMPT_LEAKAGE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PROMPT_LEAKAGE"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The category for prompt attack evaluation.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailChecksPromptAttackCategoryConfig": {
+            "type": "structure",
+            "members": {
+                "category": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailChecksPromptAttackCategory",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The prompt attack category to evaluate.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The configuration for a single prompt attack category to evaluate.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailChecksPromptAttackCategoryConfigList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.bedrockruntime#GuardrailChecksPromptAttackCategoryConfig"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A list of prompt attack category configurations.</p>",
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 3
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailChecksPromptAttackConfig": {
+            "type": "structure",
+            "members": {
+                "categories": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailChecksPromptAttackCategoryConfigList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The prompt attack categories to evaluate.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The configuration for the prompt attack check, specifying which categories to evaluate.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailChecksPromptAttackResult": {
+            "type": "structure",
+            "members": {
+                "results": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailChecksPromptAttackResultList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The per-category prompt attack results.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The prompt attack check results.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailChecksPromptAttackResultEntry": {
+            "type": "structure",
+            "members": {
+                "category": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailChecksPromptAttackCategory",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The prompt attack category that was evaluated.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "severityScore": {
+                    "target": "smithy.api#Double",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The severity score for the category, ranging from 0.0 to 1.0. Higher values indicate greater severity.</p>",
+                        "smithy.api#range": {
+                            "min": 0.0,
+                            "max": 1.0
+                        },
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The evaluation result for a single prompt attack category.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailChecksPromptAttackResultList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.bedrockruntime#GuardrailChecksPromptAttackResultEntry"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A list of prompt attack evaluation results.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailChecksPromptAttackUsage": {
+            "type": "structure",
+            "members": {
+                "textUnits": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of text units consumed by the prompt attack check.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The text unit usage for the prompt attack check.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailChecksResults": {
+            "type": "structure",
+            "members": {
+                "contentFilter": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailChecksContentFilterResult",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The content filter check results.</p>"
+                    }
+                },
+                "promptAttack": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailChecksPromptAttackResult",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The prompt attack check results.</p>"
+                    }
+                },
+                "sensitiveInformation": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailChecksSensitiveInformationResult",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The sensitive information check results.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The results from the guardrail checks evaluation, organized by check type.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailChecksRole": {
+            "type": "enum",
+            "members": {
+                "USER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "user"
+                    }
+                },
+                "ASSISTANT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "assistant"
+                    }
+                },
+                "SYSTEM": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "system"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The role of the message sender in the conversation.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailChecksSensitiveInformationConfig": {
+            "type": "structure",
+            "members": {
+                "entities": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailChecksSensitiveInformationEntityConfigList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The sensitive information entity types to detect.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The configuration for the sensitive information check, specifying which entity types to detect.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailChecksSensitiveInformationEntityConfig": {
+            "type": "structure",
+            "members": {
+                "type": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailChecksSensitiveInformationEntityType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The PII entity type to detect.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The configuration for a single sensitive information entity type to detect.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailChecksSensitiveInformationEntityConfigList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.bedrockruntime#GuardrailChecksSensitiveInformationEntityConfig"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A list of sensitive information entity configurations.</p>",
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 31
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailChecksSensitiveInformationEntityType": {
+            "type": "enum",
+            "members": {
+                "ADDRESS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ADDRESS"
+                    }
+                },
+                "AGE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AGE"
+                    }
+                },
+                "AWS_ACCESS_KEY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AWS_ACCESS_KEY"
+                    }
+                },
+                "AWS_SECRET_KEY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AWS_SECRET_KEY"
+                    }
+                },
+                "CA_HEALTH_NUMBER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CA_HEALTH_NUMBER"
+                    }
+                },
+                "CA_SOCIAL_INSURANCE_NUMBER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CA_SOCIAL_INSURANCE_NUMBER"
+                    }
+                },
+                "CREDIT_DEBIT_CARD_CVV": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CREDIT_DEBIT_CARD_CVV"
+                    }
+                },
+                "CREDIT_DEBIT_CARD_EXPIRY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CREDIT_DEBIT_CARD_EXPIRY"
+                    }
+                },
+                "CREDIT_DEBIT_CARD_NUMBER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CREDIT_DEBIT_CARD_NUMBER"
+                    }
+                },
+                "DRIVER_ID": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DRIVER_ID"
+                    }
+                },
+                "EMAIL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "EMAIL"
+                    }
+                },
+                "INTERNATIONAL_BANK_ACCOUNT_NUMBER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "INTERNATIONAL_BANK_ACCOUNT_NUMBER"
+                    }
+                },
+                "IP_ADDRESS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "IP_ADDRESS"
+                    }
+                },
+                "LICENSE_PLATE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "LICENSE_PLATE"
+                    }
+                },
+                "MAC_ADDRESS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MAC_ADDRESS"
+                    }
+                },
+                "NAME": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NAME"
+                    }
+                },
+                "PASSWORD": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PASSWORD"
+                    }
+                },
+                "PHONE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PHONE"
+                    }
+                },
+                "PIN": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PIN"
+                    }
+                },
+                "SWIFT_CODE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SWIFT_CODE"
+                    }
+                },
+                "UK_NATIONAL_HEALTH_SERVICE_NUMBER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "UK_NATIONAL_HEALTH_SERVICE_NUMBER"
+                    }
+                },
+                "UK_NATIONAL_INSURANCE_NUMBER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "UK_NATIONAL_INSURANCE_NUMBER"
+                    }
+                },
+                "UK_UNIQUE_TAXPAYER_REFERENCE_NUMBER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "UK_UNIQUE_TAXPAYER_REFERENCE_NUMBER"
+                    }
+                },
+                "URL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "URL"
+                    }
+                },
+                "USERNAME": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "USERNAME"
+                    }
+                },
+                "US_BANK_ACCOUNT_NUMBER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "US_BANK_ACCOUNT_NUMBER"
+                    }
+                },
+                "US_BANK_ROUTING_NUMBER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "US_BANK_ROUTING_NUMBER"
+                    }
+                },
+                "US_INDIVIDUAL_TAX_IDENTIFICATION_NUMBER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "US_INDIVIDUAL_TAX_IDENTIFICATION_NUMBER"
+                    }
+                },
+                "US_PASSPORT_NUMBER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "US_PASSPORT_NUMBER"
+                    }
+                },
+                "US_SOCIAL_SECURITY_NUMBER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "US_SOCIAL_SECURITY_NUMBER"
+                    }
+                },
+                "VEHICLE_IDENTIFICATION_NUMBER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "VEHICLE_IDENTIFICATION_NUMBER"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The type of personally identifiable information (PII) entity to detect.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailChecksSensitiveInformationResult": {
+            "type": "structure",
+            "members": {
+                "results": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailChecksSensitiveInformationResultList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The detected sensitive information entities.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "truncated": {
+                    "target": "smithy.api#Boolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies whether the results were truncated because the number of detected entities exceeded the maximum limit.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The sensitive information check results.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailChecksSensitiveInformationResultEntry": {
+            "type": "structure",
+            "members": {
+                "type": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailChecksSensitiveInformationEntityType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The PII entity type that was detected.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "confidenceScore": {
+                    "target": "smithy.api#Double",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The confidence score for the detection, ranging from 0.0 to 1.0. Higher values indicate greater confidence.</p>",
+                        "smithy.api#range": {
+                            "min": 0.0,
+                            "max": 1.0
+                        },
+                        "smithy.api#required": {}
+                    }
+                },
+                "beginOffset": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The start character offset of the detected entity within the content block.</p>",
+                        "smithy.api#range": {
+                            "min": 0
+                        },
+                        "smithy.api#required": {}
+                    }
+                },
+                "endOffset": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The end character offset of the detected entity within the content block.</p>",
+                        "smithy.api#range": {
+                            "min": 0
+                        },
+                        "smithy.api#required": {}
+                    }
+                },
+                "messageIndex": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The zero-based index of the message in the input messages array where the entity was detected.</p>",
+                        "smithy.api#range": {
+                            "min": 0
+                        },
+                        "smithy.api#required": {}
+                    }
+                },
+                "contentIndex": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The zero-based index of the content block within the message where the entity was detected.</p>",
+                        "smithy.api#range": {
+                            "min": 0
+                        },
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The detection result for a single sensitive information entity found in the evaluated messages.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailChecksSensitiveInformationResultList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.bedrockruntime#GuardrailChecksSensitiveInformationResultEntry"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A list of sensitive information detection results.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailChecksSensitiveInformationUsage": {
+            "type": "structure",
+            "members": {
+                "textUnits": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of text units consumed by the sensitive information check.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The text unit usage for the sensitive information check.</p>"
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailChecksTextContent": {
+            "type": "string",
+            "traits": {
+                "smithy.api#documentation": "<p>The text content of a message content block. Minimum length of 1 character.</p>",
+                "smithy.api#length": {
+                    "min": 1
+                },
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#GuardrailChecksUsageResults": {
+            "type": "structure",
+            "members": {
+                "contentFilter": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailChecksContentFilterUsage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The text unit usage for the content filter check.</p>"
+                    }
+                },
+                "promptAttack": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailChecksPromptAttackUsage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The text unit usage for the prompt attack check.</p>"
+                    }
+                },
+                "sensitiveInformation": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailChecksSensitiveInformationUsage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The text unit usage for the sensitive information check.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The text unit usage for the guardrail checks evaluation, organized by check type.</p>"
+            }
+        },
         "com.amazonaws.bedrockruntime#GuardrailConfiguration": {
             "type": "structure",
             "members": {
@@ -4785,6 +5587,9 @@
             "operations": [
                 {
                     "target": "com.amazonaws.bedrockruntime#ApplyGuardrail"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#InvokeGuardrailChecks"
                 }
             ]
         },
@@ -5402,6 +6207,84 @@
                     "max": 2048
                 },
                 "smithy.api#pattern": "^arn:aws(-[^:]+)?:bedrock:[a-z0-9-]{1,20}:[0-9]{12}:async-invoke/[a-z0-9]{12}$"
+            }
+        },
+        "com.amazonaws.bedrockruntime#InvokeGuardrailChecks": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.bedrockruntime#InvokeGuardrailChecksRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.bedrockruntime#InvokeGuardrailChecksResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.bedrockruntime#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ServiceUnavailableException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.bedrockruntime#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Evaluates messages against inline guardrail checks. You specify the check configurations directly in the request, and Amazon Bedrock returns per-check results with severity or confidence scores.</p>",
+                "smithy.api#http": {
+                    "code": 200,
+                    "method": "POST",
+                    "uri": "/guardrail-checks/invoke"
+                }
+            }
+        },
+        "com.amazonaws.bedrockruntime#InvokeGuardrailChecksRequest": {
+            "type": "structure",
+            "members": {
+                "messages": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailChecksMessageList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The messages to evaluate against the specified guardrail checks. Each message includes a role and one or more content blocks.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "checks": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailChecksConfig",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The inline check configurations that specify which guardrail checks to run against the messages.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#InvokeGuardrailChecksResponse": {
+            "type": "structure",
+            "members": {
+                "results": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailChecksResults",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The per-check results containing findings from the guardrail evaluation.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "usage": {
+                    "target": "com.amazonaws.bedrockruntime#GuardrailChecksUsageResults",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The per-check text unit consumption for the guardrail evaluation.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.bedrockruntime#InvokeModel": {

--- a/codegen/aws-models/bedrock-runtime.json
+++ b/codegen/aws-models/bedrock-runtime.json
@@ -80,6 +80,194 @@
                 "smithy.api#documentation": "<p>Describes the API operations for running inference using Amazon Bedrock models.</p>",
                 "smithy.api#httpBearerAuth": {},
                 "smithy.api#title": "Amazon Bedrock Runtime",
+                "smithy.rules#endpointBdd": {
+                    "version": "1.1",
+                    "parameters": {
+                        "Region": {
+                            "builtIn": "AWS::Region",
+                            "required": false,
+                            "documentation": "The AWS region used to dispatch the request.",
+                            "type": "string"
+                        },
+                        "UseDualStack": {
+                            "builtIn": "AWS::UseDualStack",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+                            "type": "boolean"
+                        },
+                        "UseFIPS": {
+                            "builtIn": "AWS::UseFIPS",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+                            "type": "boolean"
+                        },
+                        "Endpoint": {
+                            "builtIn": "SDK::Endpoint",
+                            "required": false,
+                            "documentation": "Override the endpoint used to send this request",
+                            "type": "string"
+                        }
+                    },
+                    "conditions": [
+                        {
+                            "fn": "isSet",
+                            "argv": [
+                                {
+                                    "ref": "Endpoint"
+                                }
+                            ]
+                        },
+                        {
+                            "fn": "isSet",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                }
+                            ]
+                        },
+                        {
+                            "fn": "aws.partition",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                }
+                            ],
+                            "assign": "PartitionResult"
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "ref": "UseFIPS"
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "ref": "UseDualStack"
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "PartitionResult"
+                                        },
+                                        "supportsDualStack"
+                                    ]
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "PartitionResult"
+                                        },
+                                        "supportsFIPS"
+                                    ]
+                                },
+                                true
+                            ]
+                        }
+                    ],
+                    "results": [
+                        {
+                            "conditions": [],
+                            "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": {
+                                    "ref": "Endpoint"
+                                },
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://bedrock-runtime-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://bedrock-runtime-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "FIPS is enabled but this partition does not support FIPS",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://bedrock-runtime.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "DualStack is enabled but this partition does not support DualStack",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://bedrock-runtime.{Region}.{PartitionResult#dnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid Configuration: Missing Region",
+                            "type": "error"
+                        }
+                    ],
+                    "root": 2,
+                    "nodeCount": 13,
+                    "nodes": "/////wAAAAH/////AAAAAAAAAAwAAAADAAAAAQAAAAQF9eELAAAAAgAAAAUF9eELAAAAAwAAAAgAAAAGAAAABAAAAAcF9eEKAAAABQX14QgF9eEJAAAABAAAAAoAAAAJAAAABgX14QYF9eEHAAAABQAAAAsF9eEFAAAABgX14QQF9eEFAAAAAwX14QEAAAANAAAABAX14QIF9eED"
+                },
                 "smithy.rules#endpointRuleSet": {
                     "version": "1.0",
                     "parameters": {
@@ -1800,6 +1988,12 @@
                     "target": "smithy.api#Unit",
                     "traits": {
                         "smithy.api#enumValue": "assistant"
+                    }
+                },
+                "SYSTEM": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "system"
                     }
                 }
             }
@@ -5336,6 +5530,13 @@
                         "smithy.api#documentation": "<p>Specifies the processing tier type used for serving the request.</p>",
                         "smithy.api#httpHeader": "X-Amzn-Bedrock-Service-Tier"
                     }
+                },
+                "requestMetadata": {
+                    "target": "com.amazonaws.bedrockruntime#RequestMetadataJson",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Key-value pairs that you can use to filter invocation logs.</p>",
+                        "smithy.api#httpHeader": "X-Amzn-Bedrock-Request-Metadata"
+                    }
                 }
             },
             "traits": {
@@ -5671,6 +5872,13 @@
                     "traits": {
                         "smithy.api#documentation": "<p>Specifies the processing tier type used for serving the request.</p>",
                         "smithy.api#httpHeader": "X-Amzn-Bedrock-Service-Tier"
+                    }
+                },
+                "requestMetadata": {
+                    "target": "com.amazonaws.bedrockruntime#RequestMetadataJson",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Key-value pairs that you can use to filter invocation logs.</p>",
+                        "smithy.api#httpHeader": "X-Amzn-Bedrock-Request-Metadata"
                     }
                 }
             },
@@ -6336,6 +6544,15 @@
                 "smithy.api#length": {
                     "min": 1,
                     "max": 16
+                },
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.bedrockruntime#RequestMetadataJson": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "max": 8500
                 },
                 "smithy.api#sensitive": {}
             }

--- a/codegen/aws-models/connecthealth.json
+++ b/codegen/aws-models/connecthealth.json
@@ -287,8 +287,112 @@
                     ],
                     "maxAge": 86400
                 },
-                "smithy.api#documentation": "<p>Health Agent for healthcare providers and patient engagement</p>",
+                "smithy.api#documentation": "<p>Amazon Connect Health is an AI-powered healthcare service built on Amazon Connect. It provides pre-built agents that automate patient engagement workflows and support clinical documentation at the point of care.</p> <p>You can use the Amazon Connect Health API to programmatically manage domains, configure patient engagement agents, run patient insights jobs, and stream ambient documentation sessions. This API reference describes the available API operations and data types for Amazon Connect Health.</p> <p>We recommend that you use the AWS SDKs to make programmatic API calls to Amazon Connect Health.</p>",
                 "smithy.api#title": "Connect Health",
+                "smithy.rules#endpointBdd": {
+                    "version": "1.1",
+                    "parameters": {
+                        "UseFIPS": {
+                            "builtIn": "AWS::UseFIPS",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+                            "type": "boolean"
+                        },
+                        "Endpoint": {
+                            "builtIn": "SDK::Endpoint",
+                            "required": false,
+                            "documentation": "Override the endpoint used to send this request",
+                            "type": "string"
+                        },
+                        "Region": {
+                            "builtIn": "AWS::Region",
+                            "required": false,
+                            "documentation": "The AWS region used to dispatch the request.",
+                            "type": "string"
+                        }
+                    },
+                    "conditions": [
+                        {
+                            "fn": "isSet",
+                            "argv": [
+                                {
+                                    "ref": "Endpoint"
+                                }
+                            ]
+                        },
+                        {
+                            "fn": "isSet",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                }
+                            ]
+                        },
+                        {
+                            "fn": "aws.partition",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                }
+                            ],
+                            "assign": "PartitionResult"
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "ref": "UseFIPS"
+                                },
+                                true
+                            ]
+                        }
+                    ],
+                    "results": [
+                        {
+                            "conditions": [],
+                            "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": {
+                                    "ref": "Endpoint"
+                                },
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://health-agent-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://health-agent.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid Configuration: Missing Region",
+                            "type": "error"
+                        }
+                    ],
+                    "root": 2,
+                    "nodeCount": 6,
+                    "nodes": "/////wAAAAH/////AAAAAAAAAAYAAAADAAAAAQAAAAQF9eEFAAAAAgAAAAUF9eEFAAAAAwX14QMF9eEEAAAAAwX14QEF9eEC"
+                },
                 "smithy.rules#endpointRuleSet": {
                     "version": "1.0",
                     "parameters": {
@@ -2107,6 +2211,22 @@
                 "smithy.api#documentation": "<p>An event containing audio data for the Medical Scribe stream</p>"
             }
         },
+        "com.amazonaws.connecthealth#MedicalScribeBinaryAudioEvent": {
+            "type": "structure",
+            "members": {
+                "audioChunk": {
+                    "target": "com.amazonaws.connecthealth#AudioChunk",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The raw binary audio data chunk</p>",
+                        "smithy.api#eventPayload": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>An event containing raw binary audio data for the Medical Scribe stream. The audio is sent as a raw binary payload rather than as a base64-encoded value.</p>"
+            }
+        },
         "com.amazonaws.connecthealth#MedicalScribeChannelDefinition": {
             "type": "structure",
             "members": {
@@ -2184,6 +2304,12 @@
                     "target": "com.amazonaws.connecthealth#MedicalScribeAudioEvent",
                     "traits": {
                         "smithy.api#documentation": "<p/>"
+                    }
+                },
+                "binaryAudioEvent": {
+                    "target": "com.amazonaws.connecthealth#MedicalScribeBinaryAudioEvent",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An event containing raw binary audio data for the Medical Scribe stream. The audio is sent as a raw binary payload rather than as a base64-encoded value.</p>"
                     }
                 },
                 "sessionControlEvent": {

--- a/codegen/aws-models/lex-runtime-v2.json
+++ b/codegen/aws-models/lex-runtime-v2.json
@@ -75,6 +75,194 @@
                 },
                 "smithy.api#documentation": "<p>This section contains documentation for the Amazon Lex V2 Runtime V2 API operations.</p>",
                 "smithy.api#title": "Amazon Lex Runtime V2",
+                "smithy.rules#endpointBdd": {
+                    "version": "1.1",
+                    "parameters": {
+                        "Region": {
+                            "builtIn": "AWS::Region",
+                            "required": false,
+                            "documentation": "The AWS region used to dispatch the request.",
+                            "type": "string"
+                        },
+                        "UseDualStack": {
+                            "builtIn": "AWS::UseDualStack",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+                            "type": "boolean"
+                        },
+                        "UseFIPS": {
+                            "builtIn": "AWS::UseFIPS",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+                            "type": "boolean"
+                        },
+                        "Endpoint": {
+                            "builtIn": "SDK::Endpoint",
+                            "required": false,
+                            "documentation": "Override the endpoint used to send this request",
+                            "type": "string"
+                        }
+                    },
+                    "conditions": [
+                        {
+                            "fn": "isSet",
+                            "argv": [
+                                {
+                                    "ref": "Endpoint"
+                                }
+                            ]
+                        },
+                        {
+                            "fn": "isSet",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                }
+                            ]
+                        },
+                        {
+                            "fn": "aws.partition",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                }
+                            ],
+                            "assign": "PartitionResult"
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "ref": "UseFIPS"
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "ref": "UseDualStack"
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "PartitionResult"
+                                        },
+                                        "supportsDualStack"
+                                    ]
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "PartitionResult"
+                                        },
+                                        "supportsFIPS"
+                                    ]
+                                },
+                                true
+                            ]
+                        }
+                    ],
+                    "results": [
+                        {
+                            "conditions": [],
+                            "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": {
+                                    "ref": "Endpoint"
+                                },
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://runtime-v2-lex-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://runtime-v2-lex-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "FIPS is enabled but this partition does not support FIPS",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://runtime-v2-lex.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "DualStack is enabled but this partition does not support DualStack",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://runtime-v2-lex.{Region}.{PartitionResult#dnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid Configuration: Missing Region",
+                            "type": "error"
+                        }
+                    ],
+                    "root": 2,
+                    "nodeCount": 13,
+                    "nodes": "/////wAAAAH/////AAAAAAAAAAwAAAADAAAAAQAAAAQF9eELAAAAAgAAAAUF9eELAAAAAwAAAAgAAAAGAAAABAAAAAcF9eEKAAAABQX14QgF9eEJAAAABAAAAAoAAAAJAAAABgX14QYF9eEHAAAABQAAAAsF9eEFAAAABgX14QQF9eEFAAAAAwX14QEAAAANAAAABAX14QIF9eED"
+                },
                 "smithy.rules#endpointRuleSet": {
                     "version": "1.0",
                     "parameters": {

--- a/codegen/aws-models/polly.json
+++ b/codegen/aws-models/polly.json
@@ -1355,6 +1355,194 @@
                 "smithy.api#xmlNamespace": {
                     "uri": "http://polly.amazonaws.com/doc/v1"
                 },
+                "smithy.rules#endpointBdd": {
+                    "version": "1.1",
+                    "parameters": {
+                        "Region": {
+                            "builtIn": "AWS::Region",
+                            "required": false,
+                            "documentation": "The AWS region used to dispatch the request.",
+                            "type": "string"
+                        },
+                        "UseDualStack": {
+                            "builtIn": "AWS::UseDualStack",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+                            "type": "boolean"
+                        },
+                        "UseFIPS": {
+                            "builtIn": "AWS::UseFIPS",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+                            "type": "boolean"
+                        },
+                        "Endpoint": {
+                            "builtIn": "SDK::Endpoint",
+                            "required": false,
+                            "documentation": "Override the endpoint used to send this request",
+                            "type": "string"
+                        }
+                    },
+                    "conditions": [
+                        {
+                            "fn": "isSet",
+                            "argv": [
+                                {
+                                    "ref": "Endpoint"
+                                }
+                            ]
+                        },
+                        {
+                            "fn": "isSet",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                }
+                            ]
+                        },
+                        {
+                            "fn": "aws.partition",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                }
+                            ],
+                            "assign": "PartitionResult"
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "ref": "UseFIPS"
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "ref": "UseDualStack"
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "PartitionResult"
+                                        },
+                                        "supportsDualStack"
+                                    ]
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "PartitionResult"
+                                        },
+                                        "supportsFIPS"
+                                    ]
+                                },
+                                true
+                            ]
+                        }
+                    ],
+                    "results": [
+                        {
+                            "conditions": [],
+                            "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": {
+                                    "ref": "Endpoint"
+                                },
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://polly-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://polly-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "FIPS is enabled but this partition does not support FIPS",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://polly.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "DualStack is enabled but this partition does not support DualStack",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://polly.{Region}.{PartitionResult#dnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid Configuration: Missing Region",
+                            "type": "error"
+                        }
+                    ],
+                    "root": 2,
+                    "nodeCount": 13,
+                    "nodes": "/////wAAAAH/////AAAAAAAAAAwAAAADAAAAAQAAAAQF9eELAAAAAgAAAAUF9eELAAAAAwAAAAgAAAAGAAAABAAAAAcF9eEKAAAABQX14QgF9eEJAAAABAAAAAoAAAAJAAAABgX14QYF9eEHAAAABQAAAAsF9eEFAAAABgX14QQF9eEFAAAAAwX14QEAAAANAAAABAX14QIF9eED"
+                },
                 "smithy.rules#endpointRuleSet": {
                     "version": "1.0",
                     "parameters": {

--- a/codegen/aws-models/sagemaker-runtime-http2.json
+++ b/codegen/aws-models/sagemaker-runtime-http2.json
@@ -187,6 +187,335 @@
                 },
                 "smithy.api#documentation": "<p> The Amazon SageMaker AI runtime HTTP/2 API. </p>",
                 "smithy.api#title": "Amazon SageMaker Runtime HTTP2",
+                "smithy.rules#endpointBdd": {
+                    "version": "1.1",
+                    "parameters": {
+                        "UseDualStack": {
+                            "builtIn": "AWS::UseDualStack",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+                            "type": "boolean"
+                        },
+                        "UseFIPS": {
+                            "builtIn": "AWS::UseFIPS",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+                            "type": "boolean"
+                        },
+                        "Endpoint": {
+                            "builtIn": "SDK::Endpoint",
+                            "required": false,
+                            "documentation": "Override the endpoint used to send this request",
+                            "type": "string"
+                        },
+                        "Region": {
+                            "builtIn": "AWS::Region",
+                            "required": false,
+                            "documentation": "The AWS region used to dispatch the request.",
+                            "type": "string"
+                        }
+                    },
+                    "conditions": [
+                        {
+                            "fn": "isSet",
+                            "argv": [
+                                {
+                                    "ref": "Endpoint"
+                                }
+                            ]
+                        },
+                        {
+                            "fn": "isSet",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                }
+                            ]
+                        },
+                        {
+                            "fn": "aws.partition",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                }
+                            ],
+                            "assign": "PartitionResult"
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "PartitionResult"
+                                        },
+                                        "name"
+                                    ]
+                                },
+                                "aws"
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "PartitionResult"
+                                        },
+                                        "name"
+                                    ]
+                                },
+                                "aws-cn"
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "PartitionResult"
+                                        },
+                                        "name"
+                                    ]
+                                },
+                                "aws-us-gov"
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "PartitionResult"
+                                        },
+                                        "name"
+                                    ]
+                                },
+                                "aws-iso"
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "PartitionResult"
+                                        },
+                                        "name"
+                                    ]
+                                },
+                                "aws-iso-b"
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "PartitionResult"
+                                        },
+                                        "name"
+                                    ]
+                                },
+                                "aws-eusc"
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "PartitionResult"
+                                        },
+                                        "name"
+                                    ]
+                                },
+                                "aws-iso-f"
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "ref": "UseFIPS"
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "PartitionResult"
+                                        },
+                                        "supportsFIPS"
+                                    ]
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "ref": "UseDualStack"
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "PartitionResult"
+                                        },
+                                        "supportsDualStack"
+                                    ]
+                                },
+                                true
+                            ]
+                        }
+                    ],
+                    "results": [
+                        {
+                            "conditions": [],
+                            "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": {
+                                    "ref": "Endpoint"
+                                },
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://runtime.sagemaker.{Region}.{PartitionResult#dnsSuffix}:8443",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://runtime.sagemaker.{Region}.{PartitionResult#dualStackDnsSuffix}:8443",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://runtime-fips.sagemaker.{Region}.{PartitionResult#dnsSuffix}:8443",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://runtime-fips.sagemaker.{Region}.{PartitionResult#dualStackDnsSuffix}:8443",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://runtime.sagemaker-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://runtime.sagemaker-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "FIPS is enabled but this partition does not support FIPS",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://runtime.sagemaker.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "DualStack is enabled but this partition does not support DualStack",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://runtime.sagemaker.{Region}.{PartitionResult#dnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid Configuration: Missing Region",
+                            "type": "error"
+                        }
+                    ],
+                    "root": 2,
+                    "nodeCount": 23,
+                    "nodes": "/////wAAAAH/////AAAAAAAAABYAAAADAAAAAQAAAAQF9eEPAAAAAgAAAAUF9eEPAAAAAwAAABMAAAAGAAAABAAAABMAAAAHAAAABQAAABMAAAAIAAAABgAAABMAAAAJAAAABwAAABMAAAAKAAAACAAAABMAAAALAAAACQAAABMAAAAMAAAACgAAAA8AAAANAAAADAAAAA4F9eEOAAAADQX14QwF9eENAAAACwAAABEAAAAQAAAADAX14QkF9eELAAAADAAAABIF9eEKAAAADQX14QgF9eEJAAAACgAAABUAAAAUAAAADAX14QUF9eEEAAAADAX14QcF9eEGAAAACgX14QEAAAAXAAAADAX14QIF9eED"
+                },
                 "smithy.rules#endpointRuleSet": {
                     "version": "1.0",
                     "parameters": {

--- a/codegen/aws-models/transcribe-streaming.json
+++ b/codegen/aws-models/transcribe-streaming.json
@@ -4009,6 +4009,194 @@
                 },
                 "smithy.api#documentation": "<p>Amazon Transcribe streaming offers four main types of real-time transcription:\n      <b>Standard</b>, <b>Medical</b>,\n      <b>Call Analytics</b>,\n      and <b>Health Scribe</b>.</p>\n         <ul>\n            <li>\n               <p>\n                  <b>Standard transcriptions</b> are the most common option. Refer\n      to  for details.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Medical transcriptions</b> are tailored to medical professionals \n      and incorporate medical terms. A common use case for this service is transcribing doctor-patient \n      dialogue in real time, so doctors can focus on their patient instead of taking notes. Refer to\n       for details.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Call Analytics transcriptions</b> are designed for use with call\n          center audio on two different channels; if you're looking for insight into customer service calls, use this \n          option. Refer to  for details.</p>\n            </li>\n            <li>\n               <p>\n                  <b>HealthScribe transcriptions</b> are designed to\n          automatically create clinical notes from patient-clinician conversations using generative AI.\n          Refer to [here] for details.</p>\n            </li>\n         </ul>",
                 "smithy.api#title": "Amazon Transcribe Streaming Service",
+                "smithy.rules#endpointBdd": {
+                    "version": "1.1",
+                    "parameters": {
+                        "Region": {
+                            "builtIn": "AWS::Region",
+                            "required": false,
+                            "documentation": "The AWS region used to dispatch the request.",
+                            "type": "string"
+                        },
+                        "UseDualStack": {
+                            "builtIn": "AWS::UseDualStack",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+                            "type": "boolean"
+                        },
+                        "UseFIPS": {
+                            "builtIn": "AWS::UseFIPS",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+                            "type": "boolean"
+                        },
+                        "Endpoint": {
+                            "builtIn": "SDK::Endpoint",
+                            "required": false,
+                            "documentation": "Override the endpoint used to send this request",
+                            "type": "string"
+                        }
+                    },
+                    "conditions": [
+                        {
+                            "fn": "isSet",
+                            "argv": [
+                                {
+                                    "ref": "Endpoint"
+                                }
+                            ]
+                        },
+                        {
+                            "fn": "isSet",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                }
+                            ]
+                        },
+                        {
+                            "fn": "aws.partition",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                }
+                            ],
+                            "assign": "PartitionResult"
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "ref": "UseFIPS"
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "ref": "UseDualStack"
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "PartitionResult"
+                                        },
+                                        "supportsDualStack"
+                                    ]
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "PartitionResult"
+                                        },
+                                        "supportsFIPS"
+                                    ]
+                                },
+                                true
+                            ]
+                        }
+                    ],
+                    "results": [
+                        {
+                            "conditions": [],
+                            "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": {
+                                    "ref": "Endpoint"
+                                },
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://transcribestreaming-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://transcribestreaming-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "FIPS is enabled but this partition does not support FIPS",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://transcribestreaming.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "DualStack is enabled but this partition does not support DualStack",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://transcribestreaming.{Region}.{PartitionResult#dnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid Configuration: Missing Region",
+                            "type": "error"
+                        }
+                    ],
+                    "root": 2,
+                    "nodeCount": 13,
+                    "nodes": "/////wAAAAH/////AAAAAAAAAAwAAAADAAAAAQAAAAQF9eELAAAAAgAAAAUF9eELAAAAAwAAAAgAAAAGAAAABAAAAAcF9eEKAAAABQX14QgF9eEJAAAABAAAAAoAAAAJAAAABgX14QYF9eEHAAAABQAAAAsF9eEFAAAABgX14QQF9eEFAAAAAwX14QEAAAANAAAABAX14QIF9eED"
+                },
                 "smithy.rules#endpointRuleSet": {
                     "version": "1.0",
                     "parameters": {


### PR DESCRIPTION
## Overview

This PR syncs the supported service models in `codegen/aws-models/` to their latest versions. 

This pulls in customer-facing API changes for `bedrock-runtime` and `connecthealth` which I've added changelog entries for (wording is defined upstream). Additionally, this PR also includes model refreshes for `lex-runtime-v2`, `polly`, `sagemaker-runtime-http2`, and `transcribe-streaming` for adding BDD endpoint rules.

> [!NOTE]
> All updated models include new `smithy.rules#endpointBdd` endpoint rule additions. Outside of BDD being reflected in `schema.py` now, our SDK doesn't do anything with BDD endpoint rules yet. I don't think a changelog entry is needed here. I added the `skip-changelog` label.
---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
