### PR TITLE
Add service model for QBusiness

### DIFF
--- a/codegen/aws-models/qbusiness.json
+++ b/codegen/aws-models/qbusiness.json
@@ -1,0 +1,17051 @@
+{
+    "smithy": "2.0",
+    "shapes": {
+        "com.amazonaws.qbusiness#APISchema": {
+            "type": "union",
+            "members": {
+                "payload": {
+                    "target": "com.amazonaws.qbusiness#Payload",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The JSON or YAML-formatted payload defining the OpenAPI schema for a custom plugin. </p>"
+                    }
+                },
+                "s3": {
+                    "target": "com.amazonaws.qbusiness#S3",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Contains details about the S3 object containing the OpenAPI schema for a custom plugin. The schema could be in either JSON or YAML format.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains details about the OpenAPI schema for a custom plugin. For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/custom-plugin.html#plugins-api-schema\">custom plugin OpenAPI schemas</a>. You can either include the schema directly in the payload field or you can upload it to an S3 bucket and specify the S3 bucket location in the <code>s3</code> field. </p>"
+            }
+        },
+        "com.amazonaws.qbusiness#APISchemaType": {
+            "type": "enum",
+            "members": {
+                "OPEN_API_V3": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "OPEN_API_V3"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#AccessConfiguration": {
+            "type": "structure",
+            "members": {
+                "accessControls": {
+                    "target": "com.amazonaws.qbusiness#AccessControls",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of <code>AccessControlList</code> objects.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "memberRelation": {
+                    "target": "com.amazonaws.qbusiness#MemberRelation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Describes the member relation within the <code>AccessControlList</code> object.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Used to configure access permissions for a document.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#AccessControl": {
+            "type": "structure",
+            "members": {
+                "principals": {
+                    "target": "com.amazonaws.qbusiness#Principals",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Contains a list of principals, where a principal can be either a <code>USER</code> or a <code>GROUP</code>. Each principal can be have the following type of document access: <code>ALLOW</code> or <code>DENY</code>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "memberRelation": {
+                    "target": "com.amazonaws.qbusiness#MemberRelation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Describes the member relation within a principal list.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A list of principals. Each principal can be either a <code>USER</code> or a <code>GROUP</code> and can be designated document access permissions of either <code>ALLOW</code> or <code>DENY</code>.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#AccessControls": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#AccessControl"
+            }
+        },
+        "com.amazonaws.qbusiness#AccessDeniedException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.qbusiness#ErrorMessage",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p> You don't have access to perform this action. Make sure you have the required permission policies and user accounts and try again.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 403
+            }
+        },
+        "com.amazonaws.qbusiness#ActionConfiguration": {
+            "type": "structure",
+            "members": {
+                "action": {
+                    "target": "com.amazonaws.qbusiness#QIamAction",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Q Business action that is allowed.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "filterConfiguration": {
+                    "target": "com.amazonaws.qbusiness#ActionFilterConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The filter configuration for the action, if any.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Specifies an allowed action and its associated filter configuration.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#ActionConfigurationList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#ActionConfiguration"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 10
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#ActionExecution": {
+            "type": "structure",
+            "members": {
+                "pluginId": {
+                    "target": "com.amazonaws.qbusiness#PluginId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the plugin the action is attached to.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "payload": {
+                    "target": "com.amazonaws.qbusiness#ActionExecutionPayload",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A mapping of field names to the field values in input that an end user provides to Amazon Q Business requests to perform their plugin action. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "payloadFieldNameSeparator": {
+                    "target": "com.amazonaws.qbusiness#ActionPayloadFieldNameSeparator",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A string used to retain information about the hierarchical contexts within an action execution event payload.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Performs an Amazon Q Business plugin action during a non-streaming chat conversation.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#ActionExecutionEvent": {
+            "type": "structure",
+            "members": {
+                "pluginId": {
+                    "target": "com.amazonaws.qbusiness#PluginId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the plugin for which the action is being requested.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "payload": {
+                    "target": "com.amazonaws.qbusiness#ActionExecutionPayload",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A mapping of field names to the field values in input that an end user provides to Amazon Q Business requests to perform their plugin action. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "payloadFieldNameSeparator": {
+                    "target": "com.amazonaws.qbusiness#ActionPayloadFieldNameSeparator",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A string used to retain information about the hierarchical contexts within a action execution event payload.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request from an end user signalling an intent to perform an Amazon Q Business plugin action during a streaming chat.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#ActionExecutionPayload": {
+            "type": "map",
+            "key": {
+                "target": "com.amazonaws.qbusiness#ActionPayloadFieldKey"
+            },
+            "value": {
+                "target": "com.amazonaws.qbusiness#ActionExecutionPayloadField"
+            }
+        },
+        "com.amazonaws.qbusiness#ActionExecutionPayloadField": {
+            "type": "structure",
+            "members": {
+                "value": {
+                    "target": "com.amazonaws.qbusiness#ActionPayloadFieldValue",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The content of a user input field in an plugin action execution payload.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A user input field in an plugin action execution payload.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#ActionFilterConfiguration": {
+            "type": "structure",
+            "members": {
+                "documentAttributeFilter": {
+                    "target": "com.amazonaws.qbusiness#AttributeFilter",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Specifies filters to apply to an allowed action.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#ActionPayloadFieldKey": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#ActionPayloadFieldNameSeparator": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#ActionPayloadFieldType": {
+            "type": "enum",
+            "members": {
+                "STRING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "STRING"
+                    }
+                },
+                "NUMBER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NUMBER"
+                    }
+                },
+                "ARRAY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ARRAY"
+                    }
+                },
+                "BOOLEAN": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "BOOLEAN"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#ActionPayloadFieldValue": {
+            "type": "document"
+        },
+        "com.amazonaws.qbusiness#ActionReview": {
+            "type": "structure",
+            "members": {
+                "pluginId": {
+                    "target": "com.amazonaws.qbusiness#PluginId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the plugin associated with the action review.</p>"
+                    }
+                },
+                "pluginType": {
+                    "target": "com.amazonaws.qbusiness#PluginType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of plugin.</p>"
+                    }
+                },
+                "payload": {
+                    "target": "com.amazonaws.qbusiness#ActionReviewPayload",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Field values that an end user needs to provide to Amazon Q Business for Amazon Q Business to perform the requested plugin action.</p>"
+                    }
+                },
+                "payloadFieldNameSeparator": {
+                    "target": "com.amazonaws.qbusiness#ActionPayloadFieldNameSeparator",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A string used to retain information about the hierarchical contexts within an action review payload.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>An output event that Amazon Q Business returns to an user who wants to perform a plugin action during a non-streaming chat conversation. It contains information about the selected action with a list of possible user input fields, some pre-populated by Amazon Q Business.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#ActionReviewEvent": {
+            "type": "structure",
+            "members": {
+                "conversationId": {
+                    "target": "com.amazonaws.qbusiness#ConversationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the conversation with which the action review event is associated.</p>"
+                    }
+                },
+                "userMessageId": {
+                    "target": "com.amazonaws.qbusiness#MessageId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the conversation with which the plugin action is associated.</p>"
+                    }
+                },
+                "systemMessageId": {
+                    "target": "com.amazonaws.qbusiness#MessageId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of an Amazon Q Business AI generated associated with the action review event.</p>"
+                    }
+                },
+                "pluginId": {
+                    "target": "com.amazonaws.qbusiness#PluginId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the plugin associated with the action review event.</p>"
+                    }
+                },
+                "pluginType": {
+                    "target": "com.amazonaws.qbusiness#PluginType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of plugin.</p>"
+                    }
+                },
+                "payload": {
+                    "target": "com.amazonaws.qbusiness#ActionReviewPayload",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Field values that an end user needs to provide to Amazon Q Business for Amazon Q Business to perform the requested plugin action.</p>"
+                    }
+                },
+                "payloadFieldNameSeparator": {
+                    "target": "com.amazonaws.qbusiness#ActionPayloadFieldNameSeparator",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A string used to retain information about the hierarchical contexts within an action review event payload.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>An output event that Amazon Q Business returns to an user who wants to perform a plugin action during a streaming chat conversation. It contains information about the selected action with a list of possible user input fields, some pre-populated by Amazon Q Business. </p>"
+            }
+        },
+        "com.amazonaws.qbusiness#ActionReviewPayload": {
+            "type": "map",
+            "key": {
+                "target": "com.amazonaws.qbusiness#ActionPayloadFieldKey"
+            },
+            "value": {
+                "target": "com.amazonaws.qbusiness#ActionReviewPayloadField"
+            }
+        },
+        "com.amazonaws.qbusiness#ActionReviewPayloadField": {
+            "type": "structure",
+            "members": {
+                "displayName": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The name of the field. </p>"
+                    }
+                },
+                "displayOrder": {
+                    "target": "com.amazonaws.qbusiness#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The display order of fields in a payload.</p>"
+                    }
+                },
+                "displayDescription": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The field level description of each action review input field. This could be an explanation of the field. In the Amazon Q Business web experience, these descriptions could be used to display as tool tips to help users understand the field. </p>"
+                    }
+                },
+                "type": {
+                    "target": "com.amazonaws.qbusiness#ActionPayloadFieldType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of field. </p>"
+                    }
+                },
+                "value": {
+                    "target": "com.amazonaws.qbusiness#ActionPayloadFieldValue",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The field value.</p>"
+                    }
+                },
+                "allowedValues": {
+                    "target": "com.amazonaws.qbusiness#ActionReviewPayloadFieldAllowedValues",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the field values that an end user can use to provide to Amazon Q Business for Amazon Q Business to perform the requested plugin action.</p>"
+                    }
+                },
+                "allowedFormat": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The expected data format for the action review input field value. For example, in PTO request, <code>from</code> and <code>to</code> would be of <code>datetime</code> allowed format. </p>"
+                    }
+                },
+                "arrayItemJsonSchema": {
+                    "target": "com.amazonaws.qbusiness#ActionReviewPayloadFieldArrayItemJsonSchema",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Use to create a custom form with array fields (fields with nested objects inside an array).</p>"
+                    }
+                },
+                "required": {
+                    "target": "smithy.api#Boolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about whether the field is required.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A user input field in an plugin action review payload.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#ActionReviewPayloadFieldAllowedValue": {
+            "type": "structure",
+            "members": {
+                "value": {
+                    "target": "com.amazonaws.qbusiness#ActionPayloadFieldValue",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The field value.</p>"
+                    }
+                },
+                "displayValue": {
+                    "target": "com.amazonaws.qbusiness#ActionPayloadFieldValue",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the field.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about the field values that an end user can use to provide to Amazon Q Business for Amazon Q Business to perform the requested plugin action.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#ActionReviewPayloadFieldAllowedValues": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#ActionReviewPayloadFieldAllowedValue"
+            }
+        },
+        "com.amazonaws.qbusiness#ActionReviewPayloadFieldArrayItemJsonSchema": {
+            "type": "document"
+        },
+        "com.amazonaws.qbusiness#ActionSummary": {
+            "type": "structure",
+            "members": {
+                "actionIdentifier": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of an Amazon Q Business plugin action.</p>"
+                    }
+                },
+                "displayName": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The display name assigned by Amazon Q Business to a plugin action. You can't modify this value.</p>"
+                    }
+                },
+                "instructionExample": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An Amazon Q Business suggested prompt and end user can use to invoke a plugin action. This value can be modified and sent as input to initiate an action. For example:</p> <ul> <li> <p>Create a Jira task</p> </li> <li> <p>Create a chat assistant task to find the root cause of a specific incident</p> </li> </ul>"
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of an Amazon Q Business plugin action.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Summary information for an Amazon Q Business plugin action.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#Actions": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#ActionSummary"
+            }
+        },
+        "com.amazonaws.qbusiness#AmazonResourceName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1011
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#Application": {
+            "type": "structure",
+            "members": {
+                "displayName": {
+                    "target": "com.amazonaws.qbusiness#ApplicationName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Amazon Q Business application.</p>"
+                    }
+                },
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier for the Amazon Q Business application.</p>"
+                    }
+                },
+                "createdAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Unix timestamp when the Amazon Q Business application was created.</p>"
+                    }
+                },
+                "updatedAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Unix timestamp when the Amazon Q Business application was last updated. </p>"
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.qbusiness#ApplicationStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status of the Amazon Q Business application. The application is ready to use when the status is <code>ACTIVE</code>.</p>"
+                    }
+                },
+                "identityType": {
+                    "target": "com.amazonaws.qbusiness#IdentityType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The authentication type being used by a Amazon Q Business application.</p>"
+                    }
+                },
+                "quickSightConfiguration": {
+                    "target": "com.amazonaws.qbusiness#QuickSightConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Quick Suite configuration for an Amazon Q Business application that uses Quick Suite as the identity provider.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Summary information for an Amazon Q Business application.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#ApplicationArn": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 1284
+                },
+                "smithy.api#pattern": "^arn:[a-z0-9-\\.]{1,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}$"
+            }
+        },
+        "com.amazonaws.qbusiness#ApplicationId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 36,
+                    "max": 36
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{35}$"
+            }
+        },
+        "com.amazonaws.qbusiness#ApplicationName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1000
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]*$"
+            }
+        },
+        "com.amazonaws.qbusiness#ApplicationResource": {
+            "type": "resource",
+            "identifiers": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId"
+                }
+            },
+            "create": {
+                "target": "com.amazonaws.qbusiness#CreateApplication"
+            },
+            "read": {
+                "target": "com.amazonaws.qbusiness#GetApplication"
+            },
+            "update": {
+                "target": "com.amazonaws.qbusiness#UpdateApplication"
+            },
+            "delete": {
+                "target": "com.amazonaws.qbusiness#DeleteApplication"
+            },
+            "list": {
+                "target": "com.amazonaws.qbusiness#ListApplications"
+            },
+            "resources": [
+                {
+                    "target": "com.amazonaws.qbusiness#DataAccessorResource"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#IndexResource"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#IntegrationResource"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#PluginResource"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#RetrieverResource"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#WebExperienceResource"
+                }
+            ],
+            "traits": {
+                "aws.cloudformation#cfnResource": {
+                    "name": "Application"
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#ApplicationStatus": {
+            "type": "enum",
+            "members": {
+                "CREATING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CREATING"
+                    }
+                },
+                "ACTIVE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ACTIVE"
+                    }
+                },
+                "DELETING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETING"
+                    }
+                },
+                "FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FAILED"
+                    }
+                },
+                "UPDATING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "UPDATING"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#Applications": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#Application"
+            }
+        },
+        "com.amazonaws.qbusiness#AppliedAttachmentsConfiguration": {
+            "type": "structure",
+            "members": {
+                "attachmentsControlMode": {
+                    "target": "com.amazonaws.qbusiness#AttachmentsControlMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about whether file upload during chat functionality is activated for your application.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration information about the file upload during chat feature for your application.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#AppliedCreatorModeConfiguration": {
+            "type": "structure",
+            "members": {
+                "creatorModeControl": {
+                    "target": "com.amazonaws.qbusiness#CreatorModeControl",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Information about whether creator mode is enabled or disabled for an Amazon Q Business application. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The creator mode specific admin controls configured for an Amazon Q Business application. Determines whether an end user can generate LLM-only responses when they use the web experience.</p> <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/guardrails.html\">Admin controls and guardrails</a> and <a href=\"https://docs.aws.amazon.com/amazonq/latest/business-use-dg/using-web-experience.html#chat-source-scope\">Conversation settings</a>.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#AppliedOrchestrationConfiguration": {
+            "type": "structure",
+            "members": {
+                "control": {
+                    "target": "com.amazonaws.qbusiness#OrchestrationControl",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Information about whether chat orchestration is enabled or disabled for an Amazon Q Business application. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The chat orchestration specific admin controls configured for an Amazon Q Business application. Determines whether Amazon Q Business automatically routes chat requests across configured plugins and data sources in your Amazon Q Business application.</p> <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/guardrails-global-controls.html#guardrails-global-orchestration\">Chat orchestration settings</a>.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#AssociatePermission": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#AssociatePermissionRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#AssociatePermissionResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Adds or updates a permission policy for a Amazon Q Business application, allowing cross-account access for an ISV. This operation creates a new policy statement for the specified Amazon Q Business application. The policy statement defines the IAM actions that the ISV is allowed to perform on the Amazon Q Business application's resources.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/policy",
+                    "method": "POST"
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#AssociatePermissionRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the Amazon Q Business application.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "statementId": {
+                    "target": "com.amazonaws.qbusiness#StatementId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A unique identifier for the policy statement.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "actions": {
+                    "target": "com.amazonaws.qbusiness#QIamActions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of Amazon Q Business actions that the ISV is allowed to perform.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "conditions": {
+                    "target": "com.amazonaws.qbusiness#PermissionConditions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The conditions that restrict when the permission is effective. These conditions can be used to limit the permission based on specific attributes of the request.</p>"
+                    }
+                },
+                "principal": {
+                    "target": "com.amazonaws.qbusiness#PrincipalRoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name of the IAM role for the ISV that is being granted permission.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#AssociatePermissionResponse": {
+            "type": "structure",
+            "members": {
+                "statement": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The JSON representation of the added permission statement.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#AssociatedGroup": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "com.amazonaws.qbusiness#GroupName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the group associated with the user. This is used to identify the group in access control decisions.</p>"
+                    }
+                },
+                "type": {
+                    "target": "com.amazonaws.qbusiness#MembershipType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the associated group. This indicates the scope of the group's applicability.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a group associated with a given user in the access control system.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#AssociatedGroups": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#AssociatedGroup"
+            }
+        },
+        "com.amazonaws.qbusiness#AssociatedUser": {
+            "type": "structure",
+            "members": {
+                "id": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the associated user. This is used to identify the user in access control decisions.</p>"
+                    }
+                },
+                "type": {
+                    "target": "com.amazonaws.qbusiness#MembershipType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the associated user. This indicates the scope of the user's association.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents an associated user in the access control system.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#AssociatedUsers": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#AssociatedUser"
+            }
+        },
+        "com.amazonaws.qbusiness#Attachment": {
+            "type": "structure",
+            "members": {
+                "attachmentId": {
+                    "target": "com.amazonaws.qbusiness#AttachmentId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business attachment.</p>"
+                    }
+                },
+                "conversationId": {
+                    "target": "com.amazonaws.qbusiness#ConversationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business conversation the attachment is associated with.</p>"
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.qbusiness#AttachmentName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Filename of the Amazon Q Business attachment.</p>"
+                    }
+                },
+                "copyFrom": {
+                    "target": "com.amazonaws.qbusiness#CopyFromSource",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A CopyFromSource containing a reference to the original source of the Amazon Q Business attachment.</p>"
+                    }
+                },
+                "fileType": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Filetype of the Amazon Q Business attachment.</p>"
+                    }
+                },
+                "fileSize": {
+                    "target": "com.amazonaws.qbusiness#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Size in bytes of the Amazon Q Business attachment.</p>"
+                    }
+                },
+                "md5chksum": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>MD5 checksum of the Amazon Q Business attachment contents.</p>"
+                    }
+                },
+                "createdAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Unix timestamp when the Amazon Q Business attachment was created.</p>"
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.qbusiness#AttachmentStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>AttachmentStatus of the Amazon Q Business attachment.</p>"
+                    }
+                },
+                "error": {
+                    "target": "com.amazonaws.qbusiness#ErrorDetail",
+                    "traits": {
+                        "smithy.api#documentation": "<p>ErrorDetail providing information about a Amazon Q Business attachment error. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>An attachment in an Amazon Q Business conversation.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#AttachmentId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+            }
+        },
+        "com.amazonaws.qbusiness#AttachmentInput": {
+            "type": "structure",
+            "members": {
+                "data": {
+                    "target": "com.amazonaws.qbusiness#Blob",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The contents of the attachment.</p>"
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.qbusiness#AttachmentName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The filename of the attachment.</p>"
+                    }
+                },
+                "copyFrom": {
+                    "target": "com.amazonaws.qbusiness#CopyFromSource",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A reference to an existing attachment.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>This is either a file directly uploaded into a web experience chat or a reference to an existing attachment that is part of a web experience chat.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#AttachmentInputEvent": {
+            "type": "structure",
+            "members": {
+                "attachment": {
+                    "target": "com.amazonaws.qbusiness#AttachmentInput"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A file input event activated by a end user request to upload files into their web experience chat.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#AttachmentList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#Attachment"
+            }
+        },
+        "com.amazonaws.qbusiness#AttachmentName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1000
+                },
+                "smithy.api#pattern": "^\\P{C}*$"
+            }
+        },
+        "com.amazonaws.qbusiness#AttachmentOutput": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "com.amazonaws.qbusiness#AttachmentName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of a file uploaded during chat.</p>"
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.qbusiness#AttachmentStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status of a file uploaded during chat.</p>"
+                    }
+                },
+                "error": {
+                    "target": "com.amazonaws.qbusiness#ErrorDetail",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An error associated with a file uploaded during chat.</p>"
+                    }
+                },
+                "attachmentId": {
+                    "target": "com.amazonaws.qbusiness#AttachmentId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the Amazon Q Business attachment.</p>"
+                    }
+                },
+                "conversationId": {
+                    "target": "com.amazonaws.qbusiness#ConversationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the Amazon Q Business conversation.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The details of a file uploaded during chat.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#AttachmentStatus": {
+            "type": "enum",
+            "members": {
+                "FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FAILED"
+                    }
+                },
+                "SUCCESS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SUCCESS"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#AttachmentsConfiguration": {
+            "type": "structure",
+            "members": {
+                "attachmentsControlMode": {
+                    "target": "com.amazonaws.qbusiness#AttachmentsControlMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Status information about whether file upload functionality is activated or deactivated for your end user.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration information for the file upload during chat feature.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#AttachmentsControlMode": {
+            "type": "enum",
+            "members": {
+                "ENABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ENABLED"
+                    }
+                },
+                "DISABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DISABLED"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#AttachmentsInput": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#AttachmentInput"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#AttachmentsOutput": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#AttachmentOutput"
+            }
+        },
+        "com.amazonaws.qbusiness#AttributeFilter": {
+            "type": "structure",
+            "members": {
+                "andAllFilters": {
+                    "target": "com.amazonaws.qbusiness#AttributeFilters",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Performs a logical <code>AND</code> operation on all supplied filters.</p>"
+                    }
+                },
+                "orAllFilters": {
+                    "target": "com.amazonaws.qbusiness#AttributeFilters",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Performs a logical <code>OR</code> operation on all supplied filters. </p>"
+                    }
+                },
+                "notFilter": {
+                    "target": "com.amazonaws.qbusiness#AttributeFilter",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Performs a logical <code>NOT</code> operation on all supplied filters. </p>"
+                    }
+                },
+                "equalsTo": {
+                    "target": "com.amazonaws.qbusiness#DocumentAttribute",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Performs an equals operation on two document attributes or metadata fields. Supported for the following <a href=\"https://docs.aws.amazon.com/amazonq/latest/api-reference/API_DocumentAttributeValue.html\">document attribute value types</a>: <code>dateValue</code>, <code>longValue</code>, <code>stringListValue</code> and <code>stringValue</code>.</p>"
+                    }
+                },
+                "containsAll": {
+                    "target": "com.amazonaws.qbusiness#DocumentAttribute",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Returns <code>true</code> when a document contains all the specified document attributes or metadata fields. Supported for the following <a href=\"https://docs.aws.amazon.com/amazonq/latest/api-reference/API_DocumentAttributeValue.html\">document attribute value types</a>: <code>stringListValue</code>.</p>"
+                    }
+                },
+                "containsAny": {
+                    "target": "com.amazonaws.qbusiness#DocumentAttribute",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Returns <code>true</code> when a document contains any of the specified document attributes or metadata fields. Supported for the following <a href=\"https://docs.aws.amazon.com/amazonq/latest/api-reference/API_DocumentAttributeValue.html\">document attribute value types</a>: <code>stringListValue</code>.</p>"
+                    }
+                },
+                "greaterThan": {
+                    "target": "com.amazonaws.qbusiness#DocumentAttribute",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Performs a greater than operation on two document attributes or metadata fields. Supported for the following <a href=\"https://docs.aws.amazon.com/amazonq/latest/api-reference/API_DocumentAttributeValue.html\">document attribute value types</a>: <code>dateValue</code> and <code>longValue</code>.</p>"
+                    }
+                },
+                "greaterThanOrEquals": {
+                    "target": "com.amazonaws.qbusiness#DocumentAttribute",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Performs a greater or equals than operation on two document attributes or metadata fields. Supported for the following <a href=\"https://docs.aws.amazon.com/amazonq/latest/api-reference/API_DocumentAttributeValue.html\">document attribute value types</a>: <code>dateValue</code> and <code>longValue</code>. </p>"
+                    }
+                },
+                "lessThan": {
+                    "target": "com.amazonaws.qbusiness#DocumentAttribute",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Performs a less than operation on two document attributes or metadata fields. Supported for the following <a href=\"https://docs.aws.amazon.com/amazonq/latest/api-reference/API_DocumentAttributeValue.html\">document attribute value types</a>: <code>dateValue</code> and <code>longValue</code>.</p>"
+                    }
+                },
+                "lessThanOrEquals": {
+                    "target": "com.amazonaws.qbusiness#DocumentAttribute",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Performs a less than or equals operation on two document attributes or metadata fields.Supported for the following <a href=\"https://docs.aws.amazon.com/amazonq/latest/api-reference/API_DocumentAttributeValue.html\">document attribute value type</a>: <code>dateValue</code> and <code>longValue</code>. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Enables filtering of responses based on document attributes or metadata fields.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#AttributeFilters": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#AttributeFilter"
+            }
+        },
+        "com.amazonaws.qbusiness#AttributeType": {
+            "type": "enum",
+            "members": {
+                "STRING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "STRING"
+                    }
+                },
+                "STRING_LIST": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "STRING_LIST"
+                    }
+                },
+                "NUMBER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NUMBER"
+                    }
+                },
+                "DATE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DATE"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#AttributeValueOperator": {
+            "type": "enum",
+            "members": {
+                "DELETE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETE"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#AudioExtractionConfiguration": {
+            "type": "structure",
+            "members": {
+                "audioExtractionStatus": {
+                    "target": "com.amazonaws.qbusiness#AudioExtractionStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status of audio extraction (ENABLED or DISABLED) for processing audio content from files.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration settings for audio content extraction and processing.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#AudioExtractionStatus": {
+            "type": "enum",
+            "members": {
+                "ENABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ENABLED"
+                    }
+                },
+                "DISABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DISABLED"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#AudioExtractionType": {
+            "type": "enum",
+            "members": {
+                "TRANSCRIPT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "TRANSCRIPT"
+                    }
+                },
+                "SUMMARY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SUMMARY"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#AudioSourceDetails": {
+            "type": "structure",
+            "members": {
+                "mediaId": {
+                    "target": "com.amazonaws.qbusiness#MediaId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Unique identifier for the audio media file.</p>"
+                    }
+                },
+                "mediaMimeType": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The MIME type of the audio file (e.g., audio/mp3, audio/wav).</p>"
+                    }
+                },
+                "startTimeMilliseconds": {
+                    "target": "com.amazonaws.qbusiness#Long",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The starting timestamp in milliseconds for the relevant audio segment.</p>"
+                    }
+                },
+                "endTimeMilliseconds": {
+                    "target": "com.amazonaws.qbusiness#Long",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ending timestamp in milliseconds for the relevant audio segment.</p>"
+                    }
+                },
+                "audioExtractionType": {
+                    "target": "com.amazonaws.qbusiness#AudioExtractionType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of audio extraction performed on the content.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Details about an audio source, including its identifier, format, and time information.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#AuthChallengeRequest": {
+            "type": "structure",
+            "members": {
+                "authorizationUrl": {
+                    "target": "com.amazonaws.qbusiness#Url",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The URL sent by Amazon Q Business to the third party authentication server to authenticate a custom plugin user through an OAuth protocol.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request made by Amazon Q Business to a third paty authentication server to authenticate a custom plugin user.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#AuthChallengeRequestEvent": {
+            "type": "structure",
+            "members": {
+                "authorizationUrl": {
+                    "target": "com.amazonaws.qbusiness#Url",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The URL sent by Amazon Q Business to a third party authentication server in response to an authentication verification event activated by an end user request to use a custom plugin. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>An authentication verification event activated by an end user request to use a custom plugin.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#AuthChallengeResponse": {
+            "type": "structure",
+            "members": {
+                "responseMap": {
+                    "target": "com.amazonaws.qbusiness#AuthorizationResponseMap",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The mapping of key-value pairs in an authentication challenge response.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains details of the authentication information received from a third party authentication server in response to an authentication challenge.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#AuthChallengeResponseEvent": {
+            "type": "structure",
+            "members": {
+                "responseMap": {
+                    "target": "com.amazonaws.qbusiness#AuthorizationResponseMap",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The mapping of key-value pairs in an authentication challenge response.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>An authentication verification event response by a third party authentication server to Amazon Q Business.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#AuthResponseKey": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 100
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#AuthResponseValue": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 2048
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#AuthorizationResponseMap": {
+            "type": "map",
+            "key": {
+                "target": "com.amazonaws.qbusiness#AuthResponseKey"
+            },
+            "value": {
+                "target": "com.amazonaws.qbusiness#AuthResponseValue"
+            }
+        },
+        "com.amazonaws.qbusiness#AutoSubscriptionConfiguration": {
+            "type": "structure",
+            "members": {
+                "autoSubscribe": {
+                    "target": "com.amazonaws.qbusiness#AutoSubscriptionStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Describes whether automatic subscriptions are enabled for an Amazon Q Business application using IAM identity federation for user management.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "defaultSubscriptionType": {
+                    "target": "com.amazonaws.qbusiness#SubscriptionType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Describes the default subscription type assigned to an Amazon Q Business application using IAM identity federation for user management. If the value for <code>autoSubscribe</code> is set to <code>ENABLED</code> you must select a value for this field.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Subscription configuration information for an Amazon Q Business application using IAM identity federation for user management. </p>"
+            }
+        },
+        "com.amazonaws.qbusiness#AutoSubscriptionStatus": {
+            "type": "enum",
+            "members": {
+                "ENABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ENABLED"
+                    }
+                },
+                "DISABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DISABLED"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#BasicAuthConfiguration": {
+            "type": "structure",
+            "members": {
+                "secretArn": {
+                    "target": "com.amazonaws.qbusiness#SecretArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the Secrets Manager secret that stores the basic authentication credentials used for plugin configuration..</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "roleArn": {
+                    "target": "com.amazonaws.qbusiness#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of an IAM role used by Amazon Q Business to access the basic authentication credentials stored in a Secrets Manager secret.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about the basic authentication credentials used to configure a plugin.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#BatchDeleteDocument": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#BatchDeleteDocumentRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#BatchDeleteDocumentResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Asynchronously deletes one or more documents added using the <code>BatchPutDocument</code> API from an Amazon Q Business index.</p> <p>You can see the progress of the deletion, and any error messages related to the process, by using CloudWatch.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/applications/{applicationId}/indices/{indexId}/documents/delete"
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#BatchDeleteDocumentRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "indexId": {
+                    "target": "com.amazonaws.qbusiness#IndexId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business index that contains the documents to delete.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "documents": {
+                    "target": "com.amazonaws.qbusiness#DeleteDocuments",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Documents deleted from the Amazon Q Business index.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "dataSourceSyncId": {
+                    "target": "com.amazonaws.qbusiness#ExecutionId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the data source sync during which the documents were deleted.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#BatchDeleteDocumentResponse": {
+            "type": "structure",
+            "members": {
+                "failedDocuments": {
+                    "target": "com.amazonaws.qbusiness#FailedDocuments",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of documents that couldn't be removed from the Amazon Q Business index. Each entry contains an error message that indicates why the document couldn't be removed from the index. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#BatchPutDocument": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#BatchPutDocumentRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#BatchPutDocumentResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Adds one or more documents to an Amazon Q Business index.</p> <p>You use this API to:</p> <ul> <li> <p>ingest your structured and unstructured documents and documents stored in an Amazon S3 bucket into an Amazon Q Business index.</p> </li> <li> <p>add custom attributes to documents in an Amazon Q Business index.</p> </li> <li> <p>attach an access control list to the documents added to an Amazon Q Business index.</p> </li> </ul> <p>You can see the progress of the deletion, and any error messages related to the process, by using CloudWatch.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/applications/{applicationId}/indices/{indexId}/documents"
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#BatchPutDocumentRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "indexId": {
+                    "target": "com.amazonaws.qbusiness#IndexId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business index to add the documents to. </p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "documents": {
+                    "target": "com.amazonaws.qbusiness#Documents",
+                    "traits": {
+                        "smithy.api#documentation": "<p>One or more documents to add to the index.</p> <important> <p>Ensure that the name of your document doesn't contain any confidential information. Amazon Q Business returns document names in chat responses and citations when relevant.</p> </important>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "roleArn": {
+                    "target": "com.amazonaws.qbusiness#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of an IAM role with permission to access your S3 bucket.</p>"
+                    }
+                },
+                "dataSourceSyncId": {
+                    "target": "com.amazonaws.qbusiness#ExecutionId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the data source sync during which the documents were added.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#BatchPutDocumentResponse": {
+            "type": "structure",
+            "members": {
+                "failedDocuments": {
+                    "target": "com.amazonaws.qbusiness#FailedDocuments",
+                    "traits": {
+                        "smithy.api#documentation": "<p> A list of documents that were not added to the Amazon Q Business index because the document failed a validation check. Each document contains an error message that indicates why the document couldn't be added to the index. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#Blob": {
+            "type": "blob"
+        },
+        "com.amazonaws.qbusiness#BlockedPhrase": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "max": 36
+                },
+                "smithy.api#pattern": "^\\P{C}*$"
+            }
+        },
+        "com.amazonaws.qbusiness#BlockedPhrases": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#BlockedPhrase"
+            }
+        },
+        "com.amazonaws.qbusiness#BlockedPhrasesConfiguration": {
+            "type": "structure",
+            "members": {
+                "blockedPhrases": {
+                    "target": "com.amazonaws.qbusiness#BlockedPhrases",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of phrases blocked from a Amazon Q Business web experience chat.</p> <note> <p>Each phrase can contain a maximum of 36 characters. The list can contain a maximum of 20 phrases.</p> </note>"
+                    }
+                },
+                "systemMessageOverride": {
+                    "target": "com.amazonaws.qbusiness#SystemMessageOverride",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configured custom message displayed to an end user informing them that they've used a blocked phrase during chat.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides information about the phrases blocked from chat by your chat control configuration.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#BlockedPhrasesConfigurationUpdate": {
+            "type": "structure",
+            "members": {
+                "blockedPhrasesToCreateOrUpdate": {
+                    "target": "com.amazonaws.qbusiness#BlockedPhrases",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Creates or updates a blocked phrases configuration in your Amazon Q Business application.</p>"
+                    }
+                },
+                "blockedPhrasesToDelete": {
+                    "target": "com.amazonaws.qbusiness#BlockedPhrases",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Deletes a blocked phrases configuration in your Amazon Q Business application.</p>"
+                    }
+                },
+                "systemMessageOverride": {
+                    "target": "com.amazonaws.qbusiness#SystemMessageOverride",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configured custom message displayed to your end user when they use blocked phrase during chat.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Updates a blocked phrases configuration in your Amazon Q Business application.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#BoostingDurationInSeconds": {
+            "type": "long",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 0,
+                    "max": 999999999
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#BrowserExtension": {
+            "type": "string",
+            "traits": {
+                "smithy.api#enum": [
+                    {
+                        "value": "FIREFOX",
+                        "name": "FIREFOX"
+                    },
+                    {
+                        "value": "CHROME",
+                        "name": "CHROME"
+                    }
+                ]
+            }
+        },
+        "com.amazonaws.qbusiness#BrowserExtensionConfiguration": {
+            "type": "structure",
+            "members": {
+                "enabledBrowserExtensions": {
+                    "target": "com.amazonaws.qbusiness#BrowserExtensionList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specify the browser extensions allowed for your Amazon Q web experience.</p> <ul> <li> <p> <code>CHROME</code> — Enables the extension for Chromium-based browsers (Google Chrome, Microsoft Edge, Opera, etc.).</p> </li> <li> <p> <code>FIREFOX</code> — Enables the extension for Mozilla Firefox.</p> </li> <li> <p> <code>CHROME</code> and <code>FIREFOX</code> — Enable the extension for Chromium-based browsers and Mozilla Firefox.</p> </li> </ul>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The container for browser extension configuration for an Amazon Q Business web experience.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#BrowserExtensionList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#BrowserExtension"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 2
+                },
+                "smithy.api#uniqueItems": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CancelSubscription": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#CancelSubscriptionRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#CancelSubscriptionResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Unsubscribes a user or a group from their pricing tier in an Amazon Q Business application. An unsubscribed user or group loses all Amazon Q Business feature access at the start of next month. </p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/applications/{applicationId}/subscriptions/{subscriptionId}"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CancelSubscriptionRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application for which the subscription is being cancelled.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "subscriptionId": {
+                    "target": "com.amazonaws.qbusiness#SubscriptionId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business subscription being cancelled.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CancelSubscriptionResponse": {
+            "type": "structure",
+            "members": {
+                "subscriptionArn": {
+                    "target": "com.amazonaws.qbusiness#SubscriptionArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon Q Business subscription being cancelled.</p>"
+                    }
+                },
+                "currentSubscription": {
+                    "target": "com.amazonaws.qbusiness#SubscriptionDetails",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of your current Amazon Q Business subscription.</p>"
+                    }
+                },
+                "nextSubscription": {
+                    "target": "com.amazonaws.qbusiness#SubscriptionDetails",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the Amazon Q Business subscription for the next month.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#Chat": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#ChatInput"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#ChatOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ExternalResourceException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#LicenseNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Starts or continues a streaming Amazon Q Business conversation.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/conversations",
+                    "method": "POST"
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#ChatInput": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application linked to a streaming Amazon Q Business conversation.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "userId": {
+                    "target": "com.amazonaws.qbusiness#UserId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the user attached to the chat input. </p>",
+                        "smithy.api#httpQuery": "userId"
+                    }
+                },
+                "userGroups": {
+                    "target": "com.amazonaws.qbusiness#UserGroups",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The group names that a user associated with the chat input belongs to.</p>",
+                        "smithy.api#httpQuery": "userGroups"
+                    }
+                },
+                "conversationId": {
+                    "target": "com.amazonaws.qbusiness#ConversationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business conversation.</p>",
+                        "smithy.api#httpQuery": "conversationId"
+                    }
+                },
+                "parentMessageId": {
+                    "target": "com.amazonaws.qbusiness#MessageId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier used to associate a user message with a AI generated response.</p>",
+                        "smithy.api#httpQuery": "parentMessageId"
+                    }
+                },
+                "clientToken": {
+                    "target": "com.amazonaws.qbusiness#ClientToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token that you provide to identify the chat input.</p>",
+                        "smithy.api#httpQuery": "clientToken",
+                        "smithy.api#idempotencyToken": {}
+                    }
+                },
+                "inputStream": {
+                    "target": "com.amazonaws.qbusiness#ChatInputStream",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The streaming input for the <code>Chat</code> API.</p>",
+                        "smithy.api#httpPayload": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ChatInputStream": {
+            "type": "union",
+            "members": {
+                "configurationEvent": {
+                    "target": "com.amazonaws.qbusiness#ConfigurationEvent",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A configuration event activated by an end user request to select a specific chat mode.</p>"
+                    }
+                },
+                "textEvent": {
+                    "target": "com.amazonaws.qbusiness#TextInputEvent",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the payload of the <code>ChatInputStream</code> event containing the end user message input.</p>"
+                    }
+                },
+                "attachmentEvent": {
+                    "target": "com.amazonaws.qbusiness#AttachmentInputEvent",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A request by an end user to upload a file during chat.</p>"
+                    }
+                },
+                "actionExecutionEvent": {
+                    "target": "com.amazonaws.qbusiness#ActionExecutionEvent",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A request from an end user to perform an Amazon Q Business plugin action.</p>"
+                    }
+                },
+                "endOfInputEvent": {
+                    "target": "com.amazonaws.qbusiness#EndOfInputEvent",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The end of the streaming input for the <code>Chat</code> API.</p>"
+                    }
+                },
+                "authChallengeResponseEvent": {
+                    "target": "com.amazonaws.qbusiness#AuthChallengeResponseEvent",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An authentication verification event response by a third party authentication server to Amazon Q Business.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The streaming input for the <code>Chat</code> API.</p>",
+                "smithy.api#streaming": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ChatMode": {
+            "type": "enum",
+            "members": {
+                "RETRIEVAL_MODE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "RETRIEVAL_MODE"
+                    }
+                },
+                "CREATOR_MODE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CREATOR_MODE"
+                    }
+                },
+                "PLUGIN_MODE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PLUGIN_MODE"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#ChatModeConfiguration": {
+            "type": "union",
+            "members": {
+                "pluginConfiguration": {
+                    "target": "com.amazonaws.qbusiness#PluginConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configuration information required to invoke chat in <code>PLUGIN_MODE</code>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration information for Amazon Q Business conversation modes.</p> <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/guardrails.html\">Admin controls and guardrails</a> and <a href=\"https://docs.aws.amazon.com/amazonq/latest/business-use-dg/using-web-experience.html#chat-source-scope\">Conversation settings</a>.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#ChatOutput": {
+            "type": "structure",
+            "members": {
+                "outputStream": {
+                    "target": "com.amazonaws.qbusiness#ChatOutputStream",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The streaming output for the <code>Chat</code> API.</p>",
+                        "smithy.api#httpPayload": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ChatOutputStream": {
+            "type": "union",
+            "members": {
+                "textEvent": {
+                    "target": "com.amazonaws.qbusiness#TextOutputEvent",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the payload of the <code>ChatOutputStream</code> event containing the AI-generated message output.</p>"
+                    }
+                },
+                "metadataEvent": {
+                    "target": "com.amazonaws.qbusiness#MetadataEvent",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A metadata event for a AI-generated text output message in a Amazon Q Business conversation. </p>"
+                    }
+                },
+                "actionReviewEvent": {
+                    "target": "com.amazonaws.qbusiness#ActionReviewEvent",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A request from Amazon Q Business to the end user for information Amazon Q Business needs to successfully complete a requested plugin action.</p>"
+                    }
+                },
+                "failedAttachmentEvent": {
+                    "target": "com.amazonaws.qbusiness#FailedAttachmentEvent",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A failed file upload event during a web experience chat.</p>"
+                    }
+                },
+                "authChallengeRequestEvent": {
+                    "target": "com.amazonaws.qbusiness#AuthChallengeRequestEvent",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An authentication verification event activated by an end user request to use a custom plugin.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The streaming output for the <code>Chat</code> API.</p>",
+                "smithy.api#streaming": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ChatResponseConfiguration": {
+            "type": "structure",
+            "members": {
+                "chatResponseConfigurationId": {
+                    "target": "com.amazonaws.qbusiness#ChatResponseConfigurationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A unique identifier for your chat response configuration settings, used to reference and manage the configuration within the Amazon Q Business service.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "chatResponseConfigurationArn": {
+                    "target": "com.amazonaws.qbusiness#ChatResponseConfigurationArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the chat response configuration, which uniquely identifies the resource across all Amazon Web Services services and accounts.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "displayName": {
+                    "target": "com.amazonaws.qbusiness#DisplayName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A human-readable name for the chat response configuration, making it easier to identify and manage multiple configurations within an organization.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "responseConfigurationSummary": {
+                    "target": "com.amazonaws.qbusiness#ResponseConfigurationSummary",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A summary of the response configuration settings, providing a concise overview of the key parameters that define how responses are generated and formatted.</p>"
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.qbusiness#ChatResponseConfigurationStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current status of the chat response configuration, indicating whether it is active, pending, or in another state that affects its availability for use in chat interactions.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "createdAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp indicating when the chat response configuration was initially created, useful for tracking the lifecycle of configuration resources.</p>"
+                    }
+                },
+                "updatedAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp indicating when the chat response configuration was last modified, helping administrators track changes and maintain version awareness.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration details that define how Amazon Q Business generates and formats responses to user queries in chat interactions. This configuration allows administrators to customize response characteristics to meet specific organizational needs and communication standards.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#ChatResponseConfigurationArn": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1284
+                },
+                "smithy.api#pattern": "^arn:[a-z0-9-\\.]{1,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}$"
+            }
+        },
+        "com.amazonaws.qbusiness#ChatResponseConfigurationDetail": {
+            "type": "structure",
+            "members": {
+                "responseConfigurations": {
+                    "target": "com.amazonaws.qbusiness#ResponseConfigurations",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A collection of specific response configuration settings that collectively define how responses are generated, formatted, and presented to users in chat interactions.</p>"
+                    }
+                },
+                "responseConfigurationSummary": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A summary of the response configuration details, providing a concise overview of the key parameters and settings that define the response generation behavior.</p>"
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.qbusiness#ChatResponseConfigurationStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current status of the chat response configuration, indicating whether it is active, pending, or in another state that affects its availability for use.</p>"
+                    }
+                },
+                "error": {
+                    "target": "com.amazonaws.qbusiness#ErrorDetail"
+                },
+                "updatedAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp indicating when the detailed chat response configuration was last modified, helping administrators track changes and maintain version awareness.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Detailed information about a chat response configuration, including comprehensive settings and parameters that define how Amazon Q Business generates and formats responses.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#ChatResponseConfigurationId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 36,
+                    "max": 36
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{35}$"
+            }
+        },
+        "com.amazonaws.qbusiness#ChatResponseConfigurationStatus": {
+            "type": "enum",
+            "members": {
+                "CREATING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CREATING"
+                    }
+                },
+                "UPDATING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "UPDATING"
+                    }
+                },
+                "FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FAILED"
+                    }
+                },
+                "ACTIVE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ACTIVE"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#ChatResponseConfigurations": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#ChatResponseConfiguration"
+            }
+        },
+        "com.amazonaws.qbusiness#ChatSync": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#ChatSyncInput"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#ChatSyncOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ExternalResourceException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#LicenseNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Starts or continues a non-streaming Amazon Q Business conversation.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/conversations?sync",
+                    "method": "POST"
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#ChatSyncInput": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application linked to the Amazon Q Business conversation.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "userId": {
+                    "target": "com.amazonaws.qbusiness#UserId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the user attached to the chat input.</p>",
+                        "smithy.api#httpQuery": "userId"
+                    }
+                },
+                "userGroups": {
+                    "target": "com.amazonaws.qbusiness#UserGroups",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The group names that a user associated with the chat input belongs to.</p>",
+                        "smithy.api#httpQuery": "userGroups"
+                    }
+                },
+                "userMessage": {
+                    "target": "com.amazonaws.qbusiness#UserMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A end user message in a conversation.</p>"
+                    }
+                },
+                "attachments": {
+                    "target": "com.amazonaws.qbusiness#AttachmentsInput",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of files uploaded directly during chat. You can upload a maximum of 5 files of upto 10 MB each.</p>"
+                    }
+                },
+                "actionExecution": {
+                    "target": "com.amazonaws.qbusiness#ActionExecution",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A request from an end user to perform an Amazon Q Business plugin action.</p>"
+                    }
+                },
+                "authChallengeResponse": {
+                    "target": "com.amazonaws.qbusiness#AuthChallengeResponse",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An authentication verification event response by a third party authentication server to Amazon Q Business.</p>"
+                    }
+                },
+                "conversationId": {
+                    "target": "com.amazonaws.qbusiness#ConversationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business conversation.</p>"
+                    }
+                },
+                "parentMessageId": {
+                    "target": "com.amazonaws.qbusiness#MessageId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the previous system message in a conversation.</p>"
+                    }
+                },
+                "attributeFilter": {
+                    "target": "com.amazonaws.qbusiness#AttributeFilter",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Enables filtering of Amazon Q Business web experience responses based on document attributes or metadata fields.</p>"
+                    }
+                },
+                "chatMode": {
+                    "target": "com.amazonaws.qbusiness#ChatMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The <code>chatMode</code> parameter determines the chat modes available to Amazon Q Business users:</p> <ul> <li> <p> <code>RETRIEVAL_MODE</code> - If you choose this mode, Amazon Q generates responses solely from the data sources connected and indexed by the application. If an answer is not found in the data sources or there are no data sources available, Amazon Q will respond with a \"<i>No Answer Found</i>\" message, unless LLM knowledge has been enabled. In that case, Amazon Q will generate a response from the LLM knowledge</p> </li> <li> <p> <code>CREATOR_MODE</code> - By selecting this mode, you can choose to generate responses only from the LLM knowledge. You can also attach files and have Amazon Q generate a response based on the data in those files. If the attached files do not contain an answer for the query, Amazon Q will automatically fall back to generating a response from the LLM knowledge.</p> </li> <li> <p> <code>PLUGIN_MODE</code> - By selecting this mode, users can choose to use plugins in chat to get their responses.</p> </li> </ul> <note> <p>If none of the modes are selected, Amazon Q will only respond using the information from the attached files.</p> </note> <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/guardrails.html\">Admin controls and guardrails</a>, <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/plugins.html\">Plugins</a>, and <a href=\"https://docs.aws.amazon.com/amazonq/latest/business-use-dg/using-web-experience.html#chat-source-scope\">Response sources</a>.</p>"
+                    }
+                },
+                "chatModeConfiguration": {
+                    "target": "com.amazonaws.qbusiness#ChatModeConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The chat mode configuration for an Amazon Q Business application.</p>"
+                    }
+                },
+                "clientToken": {
+                    "target": "com.amazonaws.qbusiness#ClientToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token that you provide to identify a chat request.</p>",
+                        "smithy.api#idempotencyToken": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ChatSyncOutput": {
+            "type": "structure",
+            "members": {
+                "conversationId": {
+                    "target": "com.amazonaws.qbusiness#ConversationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business conversation.</p>"
+                    }
+                },
+                "systemMessage": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An AI-generated message in a conversation.</p>"
+                    }
+                },
+                "systemMessageId": {
+                    "target": "com.amazonaws.qbusiness#MessageId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of an Amazon Q Business AI generated message within the conversation.</p>"
+                    }
+                },
+                "userMessageId": {
+                    "target": "com.amazonaws.qbusiness#MessageId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of an Amazon Q Business end user text input message within the conversation.</p>"
+                    }
+                },
+                "actionReview": {
+                    "target": "com.amazonaws.qbusiness#ActionReview",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A request from Amazon Q Business to the end user for information Amazon Q Business needs to successfully complete a requested plugin action.</p>"
+                    }
+                },
+                "authChallengeRequest": {
+                    "target": "com.amazonaws.qbusiness#AuthChallengeRequest",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An authentication verification event activated by an end user request to use a custom plugin.</p>"
+                    }
+                },
+                "sourceAttributions": {
+                    "target": "com.amazonaws.qbusiness#SourceAttributions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The source documents used to generate the conversation response.</p>"
+                    }
+                },
+                "failedAttachments": {
+                    "target": "com.amazonaws.qbusiness#AttachmentsOutput",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of files which failed to upload during chat.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CheckDocumentAccess": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#CheckDocumentAccessRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#CheckDocumentAccessResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Verifies if a user has access permissions for a specified document and returns the actual ACL attached to the document. Resolves user access on the document via user aliases and groups when verifying user access.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/applications/{applicationId}/index/{indexId}/users/{userId}/documents/{documentId}/check-document-access"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CheckDocumentAccessRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the application. This is required to identify the specific Amazon Q Business application context for the document access check.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "indexId": {
+                    "target": "com.amazonaws.qbusiness#IndexId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the index. Used to locate the correct index within the application where the document is stored.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "userId": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the user. Used to check the access permissions for this specific user against the document's ACL.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "documentId": {
+                    "target": "com.amazonaws.qbusiness#DocumentId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the document. Specifies which document's access permissions are being checked.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "dataSourceId": {
+                    "target": "com.amazonaws.qbusiness#DataSourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the data source. Identifies the specific data source from which the document originates. Should not be used when a document is uploaded directly with BatchPutDocument, as no dataSourceId is available or necessary. </p>",
+                        "smithy.api#httpQuery": "dataSourceId"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CheckDocumentAccessResponse": {
+            "type": "structure",
+            "members": {
+                "userGroups": {
+                    "target": "com.amazonaws.qbusiness#AssociatedGroups",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An array of groups the user is part of for the specified data source. Each group has a name and type.</p>"
+                    }
+                },
+                "userAliases": {
+                    "target": "com.amazonaws.qbusiness#AssociatedUsers",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An array of aliases associated with the user. This includes both global and local aliases, each with a name and type.</p>"
+                    }
+                },
+                "hasAccess": {
+                    "target": "smithy.api#Boolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A boolean value indicating whether the specified user has access to the document, either direct access or transitive access via groups and aliases attached to the document.</p>"
+                    }
+                },
+                "documentAcl": {
+                    "target": "com.amazonaws.qbusiness#DocumentAcl",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Access Control List (ACL) associated with the document. Includes allowlist and denylist conditions that determine user access.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ClientIdForOIDC": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 255
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9_.:/()*?=-]*$"
+            }
+        },
+        "com.amazonaws.qbusiness#ClientIdsForOIDC": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#ClientIdForOIDC"
+            }
+        },
+        "com.amazonaws.qbusiness#ClientNamespace": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 64
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9._-]*$"
+            }
+        },
+        "com.amazonaws.qbusiness#ClientToken": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 100
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#ConfigurationEvent": {
+            "type": "structure",
+            "members": {
+                "chatMode": {
+                    "target": "com.amazonaws.qbusiness#ChatMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The chat modes available to an Amazon Q Business end user.</p> <ul> <li> <p> <code>RETRIEVAL_MODE</code> - The default chat mode for an Amazon Q Business application. When this mode is enabled, Amazon Q Business generates responses only from data sources connected to an Amazon Q Business application.</p> </li> <li> <p> <code>CREATOR_MODE</code> - By selecting this mode, users can choose to generate responses only from the LLM knowledge, without consulting connected data sources, for a chat request.</p> </li> <li> <p> <code>PLUGIN_MODE</code> - By selecting this mode, users can choose to use plugins in chat.</p> </li> </ul> <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/guardrails.html\">Admin controls and guardrails</a>, <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/plugins.html\">Plugins</a>, and <a href=\"https://docs.aws.amazon.com/amazonq/latest/business-use-dg/using-web-experience.html#chat-source-scope\">Conversation settings</a>.</p>"
+                    }
+                },
+                "chatModeConfiguration": {
+                    "target": "com.amazonaws.qbusiness#ChatModeConfiguration"
+                },
+                "attributeFilter": {
+                    "target": "com.amazonaws.qbusiness#AttributeFilter"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A configuration event activated by an end user request to select a specific chat mode.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#ConflictException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.qbusiness#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The message describing a <code>ConflictException</code>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "resourceId": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the resource affected.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "resourceType": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the resource affected.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>You are trying to perform an action that conflicts with the current status of your resource. Fix any inconsistencies with your resources and try again.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 409
+            }
+        },
+        "com.amazonaws.qbusiness#ContentBlockerRule": {
+            "type": "structure",
+            "members": {
+                "systemMessageOverride": {
+                    "target": "com.amazonaws.qbusiness#SystemMessageOverride",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configured custom message displayed to an end user informing them that they've used a blocked phrase during chat.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A rule for configuring how Amazon Q Business responds when it encounters a a blocked topic. You can configure a custom message to inform your end users that they have asked about a restricted topic and suggest any next steps they should take.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#ContentRetrievalRule": {
+            "type": "structure",
+            "members": {
+                "eligibleDataSources": {
+                    "target": "com.amazonaws.qbusiness#EligibleDataSources",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies data sources in a Amazon Q Business application to use for content generation.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Rules for retrieving content from data sources connected to a Amazon Q Business application for a specific topic control configuration.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#ContentSource": {
+            "type": "union",
+            "members": {
+                "retriever": {
+                    "target": "com.amazonaws.qbusiness#RetrieverContentSource",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The retriever to use as the content source.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Specifies the source of content to search in.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#ContentType": {
+            "type": "enum",
+            "members": {
+                "PDF": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PDF"
+                    }
+                },
+                "HTML": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "HTML"
+                    }
+                },
+                "MS_WORD": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MS_WORD"
+                    }
+                },
+                "PLAIN_TEXT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PLAIN_TEXT"
+                    }
+                },
+                "PPT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PPT"
+                    }
+                },
+                "RTF": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "RTF"
+                    }
+                },
+                "XML": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "XML"
+                    }
+                },
+                "XSLT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "XSLT"
+                    }
+                },
+                "MS_EXCEL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MS_EXCEL"
+                    }
+                },
+                "CSV": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CSV"
+                    }
+                },
+                "JSON": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "JSON"
+                    }
+                },
+                "MD": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MD"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#Conversation": {
+            "type": "structure",
+            "members": {
+                "conversationId": {
+                    "target": "com.amazonaws.qbusiness#ConversationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business conversation.</p>"
+                    }
+                },
+                "title": {
+                    "target": "com.amazonaws.qbusiness#ConversationTitle",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The title of the conversation.</p>"
+                    }
+                },
+                "startTime": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The start time of the conversation.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A conversation in an Amazon Q Business application.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#ConversationId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 36,
+                    "max": 36
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{35}$"
+            }
+        },
+        "com.amazonaws.qbusiness#ConversationSource": {
+            "type": "structure",
+            "members": {
+                "conversationId": {
+                    "target": "com.amazonaws.qbusiness#ConversationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the Amazon Q Business conversation.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "attachmentId": {
+                    "target": "com.amazonaws.qbusiness#AttachmentId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the Amazon Q Business attachment.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The source reference for an existing attachment in an existing conversation.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#ConversationTitle": {
+            "type": "string"
+        },
+        "com.amazonaws.qbusiness#Conversations": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#Conversation"
+            }
+        },
+        "com.amazonaws.qbusiness#CopyFromSource": {
+            "type": "union",
+            "members": {
+                "conversation": {
+                    "target": "com.amazonaws.qbusiness#ConversationSource",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A reference to an attachment in an existing conversation.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The source reference for an existing attachment.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#CreateAnonymousWebExperienceUrl": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#CreateAnonymousWebExperienceUrlRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#CreateAnonymousWebExperienceUrlResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a unique URL for anonymous Amazon Q Business web experience. This URL can only be used once and must be used within 5 minutes after it's generated.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/experiences/{webExperienceId}/anonymous-url",
+                    "method": "POST"
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#CreateAnonymousWebExperienceUrlRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application environment attached to the web experience.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "webExperienceId": {
+                    "target": "com.amazonaws.qbusiness#WebExperienceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the web experience.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "sessionDurationInMinutes": {
+                    "target": "com.amazonaws.qbusiness#SessionDurationInMinutes",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The duration of the session associated with the unique URL for the web experience.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CreateAnonymousWebExperienceUrlResponse": {
+            "type": "structure",
+            "members": {
+                "anonymousUrl": {
+                    "target": "com.amazonaws.qbusiness#Url",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique URL for accessing the web experience.</p> <important> <p>This URL can only be used once and must be used within 5 minutes after it's generated.</p> </important>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CreateApplication": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#CreateApplicationRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#CreateApplicationResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#conditionKeys": [
+                    "aws:RequestTag/${TagKey}",
+                    "aws:TagKeys"
+                ],
+                "aws.iam#requiredActions": [
+                    "qbusiness:GetApplication",
+                    "qbusiness:UpdateApplication",
+                    "qbusiness:TagResource",
+                    "qbusiness:ListTagsForResource",
+                    "iam:PassRole",
+                    "kms:DescribeKey",
+                    "kms:CreateGrant",
+                    "sso:CreateApplication",
+                    "sso:PutApplicationAuthenticationMethod",
+                    "sso:PutApplicationAccessScope",
+                    "sso:PutApplicationGrant",
+                    "sso:DeleteApplication",
+                    "sso:DescribeInstance",
+                    "iam:GetSAMLProvider",
+                    "quicksight:DescribeAccountSubscription",
+                    "quicksight:ListNamespaces"
+                ],
+                "smithy.api#documentation": "<p>Creates an Amazon Q Business application.</p> <note> <p>There are new tiers for Amazon Q Business. Not all features in Amazon Q Business Pro are also available in Amazon Q Business Lite. For information on what's included in Amazon Q Business Lite and what's included in Amazon Q Business Pro, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/tiers.html#user-sub-tiers\">Amazon Q Business tiers</a>. You must use the Amazon Q Business console to assign subscription tiers to users. </p> <p>An Amazon Q Apps service linked role will be created if it's absent in the Amazon Web Services account when <code>QAppsConfiguration</code> is enabled in the request. For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/using-service-linked-roles-qapps.html\"> Using service-linked roles for Q Apps</a>.</p> <p>When you create an application, Amazon Q Business may securely transmit data for processing from your selected Amazon Web Services region, but within your geography. For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/cross-region-inference.html\">Cross region inference in Amazon Q Business</a>.</p> </note>",
+                "smithy.api#http": {
+                    "uri": "/applications",
+                    "method": "POST"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CreateApplicationRequest": {
+            "type": "structure",
+            "members": {
+                "displayName": {
+                    "target": "com.amazonaws.qbusiness#ApplicationName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A name for the Amazon Q Business application. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "roleArn": {
+                    "target": "com.amazonaws.qbusiness#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The Amazon Resource Name (ARN) of an IAM role with permissions to access your Amazon CloudWatch logs and metrics. If this property is not specified, Amazon Q Business will create a <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/using-service-linked-roles.html#slr-permissions\">service linked role (SLR)</a> and use it as the application's role.</p>"
+                    }
+                },
+                "identityType": {
+                    "target": "com.amazonaws.qbusiness#IdentityType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The authentication type being used by a Amazon Q Business application.</p>"
+                    }
+                },
+                "iamIdentityProviderArn": {
+                    "target": "com.amazonaws.qbusiness#IAMIdentityProviderArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of an identity provider being used by an Amazon Q Business application.</p>"
+                    }
+                },
+                "identityCenterInstanceArn": {
+                    "target": "com.amazonaws.qbusiness#InstanceArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The Amazon Resource Name (ARN) of the IAM Identity Center instance you are either creating for—or connecting to—your Amazon Q Business application.</p>"
+                    }
+                },
+                "clientIdsForOIDC": {
+                    "target": "com.amazonaws.qbusiness#ClientIdsForOIDC",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The OIDC client ID for a Amazon Q Business application.</p>"
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.qbusiness#Description",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A description for the Amazon Q Business application. </p>"
+                    }
+                },
+                "encryptionConfiguration": {
+                    "target": "com.amazonaws.qbusiness#EncryptionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the KMS key that is used to encrypt your data. Amazon Q Business doesn't support asymmetric keys.</p>"
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.qbusiness#Tags",
+                    "traits": {
+                        "aws.cloudformation#cfnMutability": "full",
+                        "smithy.api#documentation": "<p>A list of key-value pairs that identify or categorize your Amazon Q Business application. You can also use tags to help control access to the application. Tag keys and values can consist of Unicode letters, digits, white space, and any of the following symbols: _ . : / = + - @.</p>"
+                    }
+                },
+                "clientToken": {
+                    "target": "com.amazonaws.qbusiness#ClientToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token that you provide to identify the request to create your Amazon Q Business application.</p>",
+                        "smithy.api#idempotencyToken": {}
+                    }
+                },
+                "attachmentsConfiguration": {
+                    "target": "com.amazonaws.qbusiness#AttachmentsConfiguration",
+                    "traits": {
+                        "aws.cloudformation#cfnMutability": "full",
+                        "smithy.api#documentation": "<p>An option to allow end users to upload files directly during chat.</p>"
+                    }
+                },
+                "qAppsConfiguration": {
+                    "target": "com.amazonaws.qbusiness#QAppsConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An option to allow end users to create and use Amazon Q Apps in the web experience.</p>"
+                    }
+                },
+                "personalizationConfiguration": {
+                    "target": "com.amazonaws.qbusiness#PersonalizationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configuration information about chat response personalization. For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/personalizing-chat-responses.html\">Personalizing chat responses</a> </p>"
+                    }
+                },
+                "quickSightConfiguration": {
+                    "target": "com.amazonaws.qbusiness#QuickSightConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Quick Suite configuration for an Amazon Q Business application that uses Quick Suite for authentication. This configuration is required if your application uses Quick Suite as the identity provider. For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/create-quicksight-integrated-application.html\">Creating an Amazon Quick Suite integrated application</a>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CreateApplicationResponse": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application.</p>"
+                    }
+                },
+                "applicationArn": {
+                    "target": "com.amazonaws.qbusiness#ApplicationArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The Amazon Resource Name (ARN) of the Amazon Q Business application. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CreateChatResponseConfiguration": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#CreateChatResponseConfigurationRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#CreateChatResponseConfigurationResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#conditionKeys": [
+                    "aws:RequestTag/${TagKey}",
+                    "aws:TagKeys"
+                ],
+                "aws.iam#iamAction": {
+                    "requiredActions": [
+                        "qbusiness:GetChatResponseConfiguration",
+                        "qbusiness:TagResource",
+                        "qbusiness:ListTagsForResource"
+                    ]
+                },
+                "smithy.api#documentation": "<p>Creates a new chat response configuration for an Amazon Q Business application. This operation establishes a set of parameters that define how the system generates and formats responses to user queries in chat interactions.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/applications/{applicationId}/chatresponseconfigurations"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CreateChatResponseConfigurationRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the Amazon Q Business application for which to create the new chat response configuration.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "displayName": {
+                    "target": "com.amazonaws.qbusiness#DisplayName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A human-readable name for the new chat response configuration, making it easier to identify and manage among multiple configurations.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "clientToken": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A unique, case-sensitive identifier to ensure idempotency of the request. This helps prevent the same configuration from being created multiple times if retries occur.</p>",
+                        "smithy.api#idempotencyToken": {}
+                    }
+                },
+                "responseConfigurations": {
+                    "target": "com.amazonaws.qbusiness#ResponseConfigurations",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A collection of response configuration settings that define how Amazon Q Business will generate and format responses to user queries in chat interactions.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.qbusiness#Tags",
+                    "traits": {
+                        "aws.cloudformation#cfnMutability": "full",
+                        "smithy.api#documentation": "<p>A list of key-value pairs to apply as tags to the new chat response configuration, enabling categorization and management of resources across Amazon Web Services services.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CreateChatResponseConfigurationResponse": {
+            "type": "structure",
+            "members": {
+                "chatResponseConfigurationId": {
+                    "target": "com.amazonaws.qbusiness#ChatResponseConfigurationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier assigned to a newly created chat response configuration, used for subsequent operations on this resource.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "chatResponseConfigurationArn": {
+                    "target": "com.amazonaws.qbusiness#ChatResponseConfigurationArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the newly created chat response configuration, which uniquely identifies the resource across all Amazon Web Services services. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CreateDataAccessor": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#CreateDataAccessorRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#CreateDataAccessorResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#conditionKeys": [
+                    "aws:RequestTag/${TagKey}",
+                    "aws:TagKeys"
+                ],
+                "aws.iam#requiredActions": [
+                    "qbusiness:GetDataAccessor",
+                    "qbusiness:TagResource",
+                    "qbusiness:ListTagsForResource"
+                ],
+                "smithy.api#documentation": "<p>Creates a new data accessor for an ISV to access data from a Amazon Q Business application. The data accessor is an entity that represents the ISV's access to the Amazon Q Business application's data. It includes the IAM role ARN for the ISV, a friendly name, and a set of action configurations that define the specific actions the ISV is allowed to perform and any associated data filters. When the data accessor is created, an IAM Identity Center application is also created to manage the ISV's identity and authentication for accessing the Amazon Q Business application.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/dataaccessors",
+                    "method": "POST"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CreateDataAccessorRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the Amazon Q Business application.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "principal": {
+                    "target": "com.amazonaws.qbusiness#PrincipalRoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role for the ISV that will be accessing the data.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "actionConfigurations": {
+                    "target": "com.amazonaws.qbusiness#ActionConfigurationList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of action configurations specifying the allowed actions and any associated filters.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "clientToken": {
+                    "target": "com.amazonaws.qbusiness#ClientToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A unique, case-sensitive identifier you provide to ensure idempotency of the request.</p>",
+                        "smithy.api#idempotencyToken": {}
+                    }
+                },
+                "displayName": {
+                    "target": "com.amazonaws.qbusiness#DataAccessorName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A friendly name for the data accessor.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "authenticationDetail": {
+                    "target": "com.amazonaws.qbusiness#DataAccessorAuthenticationDetail",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The authentication configuration details for the data accessor. This specifies how the ISV will authenticate when accessing data through this data accessor.</p>"
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.qbusiness#Tags",
+                    "traits": {
+                        "aws.cloudformation#cfnMutability": "full",
+                        "smithy.api#documentation": "<p>The tags to associate with the data accessor.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CreateDataAccessorResponse": {
+            "type": "structure",
+            "members": {
+                "dataAccessorId": {
+                    "target": "com.amazonaws.qbusiness#DataAccessorId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the created data accessor.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "idcApplicationArn": {
+                    "target": "com.amazonaws.qbusiness#IdcApplicationArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM Identity Center application created for this data accessor.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "dataAccessorArn": {
+                    "target": "com.amazonaws.qbusiness#DataAccessorArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the created data accessor.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CreateDataSource": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#CreateDataSourceRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#CreateDataSourceResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#conditionKeys": [
+                    "aws:RequestTag/${TagKey}",
+                    "aws:TagKeys"
+                ],
+                "aws.iam#requiredActions": [
+                    "qbusiness:GetDataSource",
+                    "qbusiness:TagResource",
+                    "qbusiness:ListTagsForResource",
+                    "iam:PassRole"
+                ],
+                "smithy.api#documentation": "<p>Creates a data source connector for an Amazon Q Business application.</p> <p> <code>CreateDataSource</code> is a synchronous operation. The operation returns 200 if the data source was successfully created. Otherwise, an exception is raised.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/indices/{indexId}/datasources",
+                    "method": "POST"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CreateDataSourceRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The identifier of the Amazon Q Business application the data source will be attached to.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "indexId": {
+                    "target": "com.amazonaws.qbusiness#IndexId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the index that you want to use with the data source connector.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "displayName": {
+                    "target": "com.amazonaws.qbusiness#DataSourceName",
+                    "traits": {
+                        "aws.cloudformation#cfnMutability": "full",
+                        "smithy.api#documentation": "<p>A name for the data source connector.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "configuration": {
+                    "target": "com.amazonaws.qbusiness#DataSourceConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configuration information to connect your data source repository to Amazon Q Business. Use this parameter to provide a JSON schema with configuration information specific to your data source connector.</p> <p>Each data source has a JSON schema provided by Amazon Q Business that you must use. For example, the Amazon S3 and Web Crawler connectors require the following JSON schemas:</p> <ul> <li> <p> <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/s3-api.html\">Amazon S3 JSON schema</a> </p> </li> <li> <p> <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/web-crawler-api.html\">Web Crawler JSON schema</a> </p> </li> </ul> <p>You can find configuration templates for your specific data source using the following steps:</p> <ol> <li> <p>Navigate to the <a href=\"https://docs.aws.amazon.com/amazonq/latest/business-use-dg/connectors-list.html\">Supported connectors</a> page in the Amazon Q Business User Guide, and select the data source of your choice.</p> </li> <li> <p>Then, from your specific data source connector page, select <b>Using the API</b>. You will find the JSON schema for your data source, including parameter descriptions, in this section.</p> </li> </ol>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "vpcConfiguration": {
+                    "target": "com.amazonaws.qbusiness#DataSourceVpcConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configuration information for an Amazon VPC (Virtual Private Cloud) to connect to your data source. For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/business-use-dg/connector-vpc.html\">Using Amazon VPC with Amazon Q Business connectors</a>.</p>"
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.qbusiness#Description",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A description for the data source connector.</p>"
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.qbusiness#Tags",
+                    "traits": {
+                        "aws.cloudformation#cfnMutability": "full",
+                        "smithy.api#documentation": "<p>A list of key-value pairs that identify or categorize the data source connector. You can also use tags to help control access to the data source connector. Tag keys and values can consist of Unicode letters, digits, white space, and any of the following symbols: _ . : / = + - @.</p>"
+                    }
+                },
+                "syncSchedule": {
+                    "target": "com.amazonaws.qbusiness#SyncSchedule",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Sets the frequency for Amazon Q Business to check the documents in your data source repository and update your index. If you don't set a schedule, Amazon Q Business won't periodically update the index.</p> <p>Specify a <code>cron-</code> format schedule string or an empty string to indicate that the index is updated on demand. You can't specify the <code>Schedule</code> parameter when the <code>Type</code> parameter is set to <code>CUSTOM</code>. If you do, you receive a <code>ValidationException</code> exception. </p>"
+                    }
+                },
+                "roleArn": {
+                    "target": "com.amazonaws.qbusiness#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of an IAM role with permission to access the data source and required resources. This field is required for all connector types except custom connectors, where it is optional.</p>"
+                    }
+                },
+                "clientToken": {
+                    "target": "com.amazonaws.qbusiness#ClientToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token you provide to identify a request to create a data source connector. Multiple calls to the <code>CreateDataSource</code> API with the same client token will create only one data source connector. </p>",
+                        "smithy.api#idempotencyToken": {}
+                    }
+                },
+                "documentEnrichmentConfiguration": {
+                    "target": "com.amazonaws.qbusiness#DocumentEnrichmentConfiguration"
+                },
+                "mediaExtractionConfiguration": {
+                    "target": "com.amazonaws.qbusiness#MediaExtractionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configuration for extracting information from media in documents during ingestion.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CreateDataSourceResponse": {
+            "type": "structure",
+            "members": {
+                "dataSourceId": {
+                    "target": "com.amazonaws.qbusiness#DataSourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the data source connector.</p>"
+                    }
+                },
+                "dataSourceArn": {
+                    "target": "com.amazonaws.qbusiness#DataSourceArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The Amazon Resource Name (ARN) of a data source in an Amazon Q Business application. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CreateIndex": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#CreateIndexRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#CreateIndexResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#conditionKeys": [
+                    "aws:RequestTag/${TagKey}",
+                    "aws:TagKeys"
+                ],
+                "aws.iam#requiredActions": [
+                    "qbusiness:GetIndex",
+                    "qbusiness:TagResource",
+                    "qbusiness:ListTagsForResource"
+                ],
+                "smithy.api#documentation": "<p>Creates an Amazon Q Business index.</p> <p>To determine if index creation has completed, check the <code>Status</code> field returned from a call to <code>DescribeIndex</code>. The <code>Status</code> field is set to <code>ACTIVE</code> when the index is ready to use.</p> <p>Once the index is active, you can index your documents using the <a href=\"https://docs.aws.amazon.com/amazonq/latest/api-reference/API_BatchPutDocument.html\"> <code>BatchPutDocument</code> </a> API or the <a href=\"https://docs.aws.amazon.com/amazonq/latest/api-reference/API_CreateDataSource.html\"> <code>CreateDataSource</code> </a> API.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/indices",
+                    "method": "POST"
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#CreateIndexRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application using the index.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "displayName": {
+                    "target": "com.amazonaws.qbusiness#IndexName",
+                    "traits": {
+                        "aws.cloudformation#cfnMutability": "full",
+                        "smithy.api#documentation": "<p>A name for the Amazon Q Business index.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.qbusiness#Description",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A description for the Amazon Q Business index.</p>"
+                    }
+                },
+                "type": {
+                    "target": "com.amazonaws.qbusiness#IndexType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The index type that's suitable for your needs. For more information on what's included in each type of index, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/tiers.html#index-tiers\">Amazon Q Business tiers</a>.</p>"
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.qbusiness#Tags",
+                    "traits": {
+                        "aws.cloudformation#cfnMutability": "full",
+                        "smithy.api#documentation": "<p>A list of key-value pairs that identify or categorize the index. You can also use tags to help control access to the index. Tag keys and values can consist of Unicode letters, digits, white space, and any of the following symbols: _ . : / = + - @.</p>"
+                    }
+                },
+                "capacityConfiguration": {
+                    "target": "com.amazonaws.qbusiness#IndexCapacityConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The capacity units you want to provision for your index. You can add and remove capacity to fit your usage needs.</p>"
+                    }
+                },
+                "clientToken": {
+                    "target": "com.amazonaws.qbusiness#ClientToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token that you provide to identify the request to create an index. Multiple calls to the <code>CreateIndex</code> API with the same client token will create only one index.</p>",
+                        "smithy.api#idempotencyToken": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CreateIndexResponse": {
+            "type": "structure",
+            "members": {
+                "indexId": {
+                    "target": "com.amazonaws.qbusiness#IndexId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier for the Amazon Q Business index.</p>"
+                    }
+                },
+                "indexArn": {
+                    "target": "com.amazonaws.qbusiness#IndexArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The Amazon Resource Name (ARN) of an Amazon Q Business index.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CreatePlugin": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#CreatePluginRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#CreatePluginResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#conditionKeys": [
+                    "aws:RequestTag/${TagKey}",
+                    "aws:TagKeys"
+                ],
+                "aws.iam#requiredActions": [
+                    "qbusiness:GetPlugin",
+                    "qbusiness:TagResource",
+                    "qbusiness:ListTagsForResource",
+                    "iam:PassRole"
+                ],
+                "smithy.api#documentation": "<p>Creates an Amazon Q Business plugin.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/applications/{applicationId}/plugins"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CreatePluginRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the application that will contain the plugin.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "displayName": {
+                    "target": "com.amazonaws.qbusiness#PluginName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A the name for your plugin.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "type": {
+                    "target": "com.amazonaws.qbusiness#PluginType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of plugin you want to create.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "authConfiguration": {
+                    "target": "com.amazonaws.qbusiness#PluginAuthConfiguration",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                },
+                "serverUrl": {
+                    "target": "com.amazonaws.qbusiness#Url",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The source URL used for plugin configuration.</p>"
+                    }
+                },
+                "customPluginConfiguration": {
+                    "target": "com.amazonaws.qbusiness#CustomPluginConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Contains configuration for a custom plugin.</p>"
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.qbusiness#Tags",
+                    "traits": {
+                        "aws.cloudformation#cfnMutability": "full",
+                        "smithy.api#documentation": "<p>A list of key-value pairs that identify or categorize the data source connector. You can also use tags to help control access to the data source connector. Tag keys and values can consist of Unicode letters, digits, white space, and any of the following symbols: _ . : / = + - @.</p>"
+                    }
+                },
+                "clientToken": {
+                    "target": "com.amazonaws.qbusiness#ClientToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token that you provide to identify the request to create your Amazon Q Business plugin.</p>",
+                        "smithy.api#idempotencyToken": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CreatePluginResponse": {
+            "type": "structure",
+            "members": {
+                "pluginId": {
+                    "target": "com.amazonaws.qbusiness#PluginId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the plugin created.</p>"
+                    }
+                },
+                "pluginArn": {
+                    "target": "com.amazonaws.qbusiness#PluginArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of a plugin.</p>"
+                    }
+                },
+                "buildStatus": {
+                    "target": "com.amazonaws.qbusiness#PluginBuildStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current status of a plugin. A plugin is modified asynchronously.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CreateRetriever": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#CreateRetrieverRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#CreateRetrieverResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#conditionKeys": [
+                    "aws:RequestTag/${TagKey}",
+                    "aws:TagKeys"
+                ],
+                "aws.iam#requiredActions": [
+                    "qbusiness:TagResource",
+                    "qbusiness:ListTagsForResource",
+                    "qbusiness:GetRetriever",
+                    "iam:PassRole"
+                ],
+                "smithy.api#documentation": "<p>Adds a retriever to your Amazon Q Business application.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/applications/{applicationId}/retrievers"
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#CreateRetrieverRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of your Amazon Q Business application.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "type": {
+                    "target": "com.amazonaws.qbusiness#RetrieverType",
+                    "traits": {
+                        "aws.cloudformation#cfnMutability": "create-and-read",
+                        "smithy.api#documentation": "<p>The type of retriever you are using.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "displayName": {
+                    "target": "com.amazonaws.qbusiness#RetrieverName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of your retriever.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "configuration": {
+                    "target": "com.amazonaws.qbusiness#RetrieverConfiguration",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                },
+                "roleArn": {
+                    "target": "com.amazonaws.qbusiness#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of an IAM role used by Amazon Q Business to access the basic authentication credentials stored in a Secrets Manager secret.</p>"
+                    }
+                },
+                "clientToken": {
+                    "target": "com.amazonaws.qbusiness#ClientToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token that you provide to identify the request to create your Amazon Q Business application retriever.</p>",
+                        "smithy.api#idempotencyToken": {}
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.qbusiness#Tags",
+                    "traits": {
+                        "aws.cloudformation#cfnMutability": "full",
+                        "smithy.api#documentation": "<p>A list of key-value pairs that identify or categorize the retriever. You can also use tags to help control access to the retriever. Tag keys and values can consist of Unicode letters, digits, white space, and any of the following symbols: _ . : / = + - @.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CreateRetrieverResponse": {
+            "type": "structure",
+            "members": {
+                "retrieverId": {
+                    "target": "com.amazonaws.qbusiness#RetrieverId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the retriever you are using.</p>"
+                    }
+                },
+                "retrieverArn": {
+                    "target": "com.amazonaws.qbusiness#RetrieverArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of an IAM role associated with a retriever.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CreateSubscription": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#CreateSubscriptionRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#CreateSubscriptionResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Subscribes an IAM Identity Center user or a group to a pricing tier for an Amazon Q Business application.</p> <p>Amazon Q Business offers two subscription tiers: <code>Q_LITE</code> and <code>Q_BUSINESS</code>. Subscription tier determines feature access for the user. For more information on subscriptions and pricing tiers, see <a href=\"https://aws.amazon.com/q/business/pricing/\">Amazon Q Business pricing</a>.</p> <note> <p>For an example IAM role policy for assigning subscriptions, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/setting-up.html#permissions\">Set up required permissions</a> in the Amazon Q Business User Guide.</p> </note>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/applications/{applicationId}/subscriptions"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CreateSubscriptionRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application the subscription should be added to.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "principal": {
+                    "target": "com.amazonaws.qbusiness#SubscriptionPrincipal",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The IAM Identity Center <code>UserId</code> or <code>GroupId</code> of a user or group in the IAM Identity Center instance connected to the Amazon Q Business application.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "type": {
+                    "target": "com.amazonaws.qbusiness#SubscriptionType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of Amazon Q Business subscription you want to create.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "clientToken": {
+                    "target": "com.amazonaws.qbusiness#ClientToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token that you provide to identify the request to create a subscription for your Amazon Q Business application.</p>",
+                        "smithy.api#idempotencyToken": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CreateSubscriptionResponse": {
+            "type": "structure",
+            "members": {
+                "subscriptionId": {
+                    "target": "com.amazonaws.qbusiness#SubscriptionId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business subscription created.</p>"
+                    }
+                },
+                "subscriptionArn": {
+                    "target": "com.amazonaws.qbusiness#SubscriptionArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon Q Business subscription created.</p>"
+                    }
+                },
+                "currentSubscription": {
+                    "target": "com.amazonaws.qbusiness#SubscriptionDetails",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of your current Amazon Q Business subscription.</p>"
+                    }
+                },
+                "nextSubscription": {
+                    "target": "com.amazonaws.qbusiness#SubscriptionDetails",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the Amazon Q Business subscription for the next month.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CreateUser": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#CreateUserRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#CreateUserResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a universally unique identifier (UUID) mapped to a list of local user ids within an application.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/applications/{applicationId}/users"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CreateUserRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the application for which the user mapping will be created.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "userId": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The user emails attached to a user mapping.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "userAliases": {
+                    "target": "com.amazonaws.qbusiness#UserAliases",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of user aliases in the mapping.</p>",
+                        "smithy.api#length": {
+                            "min": 0,
+                            "max": 100
+                        }
+                    }
+                },
+                "clientToken": {
+                    "target": "com.amazonaws.qbusiness#ClientToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token that you provide to identify the request to create your Amazon Q Business user mapping.</p>",
+                        "smithy.api#idempotencyToken": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CreateUserResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CreateWebExperience": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#CreateWebExperienceRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#CreateWebExperienceResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#conditionKeys": [
+                    "aws:RequestTag/${TagKey}",
+                    "aws:TagKeys"
+                ],
+                "aws.iam#requiredActions": [
+                    "qbusiness:GetWebExperience",
+                    "qbusiness:TagResource",
+                    "qbusiness:ListTagsForResource",
+                    "iam:PassRole",
+                    "sso:PutApplicationGrant",
+                    "sso:UpdateApplication"
+                ],
+                "smithy.api#documentation": "<p>Creates an Amazon Q Business web experience.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/experiences",
+                    "method": "POST"
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#CreateWebExperienceRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business web experience.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "title": {
+                    "target": "com.amazonaws.qbusiness#WebExperienceTitle",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The title for your Amazon Q Business web experience.</p>"
+                    }
+                },
+                "subtitle": {
+                    "target": "com.amazonaws.qbusiness#WebExperienceSubtitle",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A subtitle to personalize your Amazon Q Business web experience.</p>"
+                    }
+                },
+                "welcomeMessage": {
+                    "target": "com.amazonaws.qbusiness#WebExperienceWelcomeMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The customized welcome message for end users of an Amazon Q Business web experience.</p>"
+                    }
+                },
+                "samplePromptsControlMode": {
+                    "target": "com.amazonaws.qbusiness#WebExperienceSamplePromptsControlMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Determines whether sample prompts are enabled in the web experience for an end user.</p>"
+                    }
+                },
+                "origins": {
+                    "target": "com.amazonaws.qbusiness#WebExperienceOrigins",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Sets the website domain origins that are allowed to embed the Amazon Q Business web experience. The <i>domain origin</i> refers to the base URL for accessing a website including the protocol (<code>http/https</code>), the domain name, and the port number (if specified). </p> <note> <p>You must only submit a <i>base URL</i> and not a full path. For example, <code>https://docs.aws.amazon.com</code>.</p> </note>"
+                    }
+                },
+                "roleArn": {
+                    "target": "com.amazonaws.qbusiness#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the service role attached to your web experience.</p> <note> <p>The <code>roleArn</code> parameter is required when your Amazon Q Business application is created with IAM Identity Center. It is not required for SAML-based applications.</p> </note>"
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.qbusiness#Tags",
+                    "traits": {
+                        "aws.cloudformation#cfnMutability": "full",
+                        "smithy.api#documentation": "<p>A list of key-value pairs that identify or categorize your Amazon Q Business web experience. You can also use tags to help control access to the web experience. Tag keys and values can consist of Unicode letters, digits, white space, and any of the following symbols: _ . : / = + - @.</p>"
+                    }
+                },
+                "clientToken": {
+                    "target": "com.amazonaws.qbusiness#ClientToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token you provide to identify a request to create an Amazon Q Business web experience. </p>",
+                        "smithy.api#idempotencyToken": {}
+                    }
+                },
+                "identityProviderConfiguration": {
+                    "target": "com.amazonaws.qbusiness#IdentityProviderConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the identity provider (IdP) used to authenticate end users of an Amazon Q Business web experience.</p>"
+                    }
+                },
+                "browserExtensionConfiguration": {
+                    "target": "com.amazonaws.qbusiness#BrowserExtensionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The browser extension configuration for an Amazon Q Business web experience.</p> <note> <p> For Amazon Q Business application using external OIDC-compliant identity providers (IdPs). The IdP administrator must add the browser extension sign-in redirect URLs to the IdP application. For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/browser-extensions.html\">Configure external OIDC identity provider for your browser extensions.</a>. </p> </note>"
+                    }
+                },
+                "customizationConfiguration": {
+                    "target": "com.amazonaws.qbusiness#CustomizationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Sets the custom logo, favicon, font, and color used in the Amazon Q web experience. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CreateWebExperienceResponse": {
+            "type": "structure",
+            "members": {
+                "webExperienceId": {
+                    "target": "com.amazonaws.qbusiness#WebExperienceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business web experience.</p>"
+                    }
+                },
+                "webExperienceArn": {
+                    "target": "com.amazonaws.qbusiness#WebExperienceArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The Amazon Resource Name (ARN) of an Amazon Q Business web experience.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#CreatorModeConfiguration": {
+            "type": "structure",
+            "members": {
+                "creatorModeControl": {
+                    "target": "com.amazonaws.qbusiness#CreatorModeControl",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Status information about whether <code>CREATOR_MODE</code> has been enabled or disabled. The default status is <code>DISABLED</code>.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration information required to invoke chat in <code>CREATOR_MODE</code>.</p> <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/guardrails.html\">Admin controls and guardrails</a> and <a href=\"https://docs.aws.amazon.com/amazonq/latest/business-use-dg/using-web-experience.html#chat-source-scope\">Conversation settings</a>.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#CreatorModeControl": {
+            "type": "enum",
+            "members": {
+                "ENABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ENABLED"
+                    }
+                },
+                "DISABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DISABLED"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#CustomCSSUrl": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 1284
+                },
+                "smithy.api#pattern": "^(https?://[a-zA-Z0-9-_.+%/]+\\.css)?$"
+            }
+        },
+        "com.amazonaws.qbusiness#CustomPluginConfiguration": {
+            "type": "structure",
+            "members": {
+                "description": {
+                    "target": "com.amazonaws.qbusiness#PluginDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A description for your custom plugin configuration.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "apiSchemaType": {
+                    "target": "com.amazonaws.qbusiness#APISchemaType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of OpenAPI schema to use.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "apiSchema": {
+                    "target": "com.amazonaws.qbusiness#APISchema",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Contains either details about the S3 object containing the OpenAPI schema for the action group or the JSON or YAML-formatted payload defining the schema.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p> Configuration information required to create a custom plugin.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#CustomizationConfiguration": {
+            "type": "structure",
+            "members": {
+                "customCSSUrl": {
+                    "target": "com.amazonaws.qbusiness#CustomCSSUrl",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Provides the URL where the custom CSS file is hosted for an Amazon Q web experience.</p>"
+                    }
+                },
+                "logoUrl": {
+                    "target": "com.amazonaws.qbusiness#LogoUrl",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Provides the URL where the custom logo file is hosted for an Amazon Q web experience.</p>"
+                    }
+                },
+                "fontUrl": {
+                    "target": "com.amazonaws.qbusiness#FontUrl",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Provides the URL where the custom font file is hosted for an Amazon Q web experience.</p>"
+                    }
+                },
+                "faviconUrl": {
+                    "target": "com.amazonaws.qbusiness#FaviconUrl",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Provides the URL where the custom favicon file is hosted for an Amazon Q web experience.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains the configuration information to customize the logo, font, and color of an Amazon Q Business web experience with individual files for each property or a CSS file for them all.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#DataAccessor": {
+            "type": "structure",
+            "members": {
+                "displayName": {
+                    "target": "com.amazonaws.qbusiness#DataAccessorName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The friendly name of the data accessor.</p>"
+                    }
+                },
+                "dataAccessorId": {
+                    "target": "com.amazonaws.qbusiness#DataAccessorId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the data accessor.</p>"
+                    }
+                },
+                "dataAccessorArn": {
+                    "target": "com.amazonaws.qbusiness#DataAccessorArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the data accessor.</p>"
+                    }
+                },
+                "idcApplicationArn": {
+                    "target": "com.amazonaws.qbusiness#IdcApplicationArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the associated IAM Identity Center application.</p>"
+                    }
+                },
+                "principal": {
+                    "target": "com.amazonaws.qbusiness#PrincipalRoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role for the ISV associated with this data accessor.</p>"
+                    }
+                },
+                "authenticationDetail": {
+                    "target": "com.amazonaws.qbusiness#DataAccessorAuthenticationDetail",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The authentication configuration details for the data accessor. This specifies how the ISV authenticates when accessing data through this data accessor.</p>"
+                    }
+                },
+                "createdAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the data accessor was created.</p>"
+                    }
+                },
+                "updatedAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the data accessor was last updated.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides summary information about a data accessor.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#DataAccessorArn": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 1284
+                },
+                "smithy.api#pattern": "^arn:[a-z0-9-\\.]{1,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}$"
+            }
+        },
+        "com.amazonaws.qbusiness#DataAccessorAuthenticationConfiguration": {
+            "type": "union",
+            "members": {
+                "idcTrustedTokenIssuerConfiguration": {
+                    "target": "com.amazonaws.qbusiness#DataAccessorIdcTrustedTokenIssuerConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configuration for IAM Identity Center Trusted Token Issuer (TTI) authentication used when the authentication type is <code>AWS_IAM_IDC_TTI</code>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A union type that contains the specific authentication configuration based on the authentication type selected.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#DataAccessorAuthenticationDetail": {
+            "type": "structure",
+            "members": {
+                "authenticationType": {
+                    "target": "com.amazonaws.qbusiness#DataAccessorAuthenticationType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of authentication to use for the data accessor. This determines how the ISV authenticates when accessing data. You can use one of two authentication types:</p> <ul> <li> <p> <code>AWS_IAM_IDC_TTI</code> - Authentication using IAM Identity Center Trusted Token Issuer (TTI). This authentication type allows the ISV to use a trusted token issuer to generate tokens for accessing the data.</p> </li> <li> <p> <code>AWS_IAM_IDC_AUTH_CODE</code> - Authentication using IAM Identity Center authorization code flow. This authentication type uses the standard OAuth 2.0 authorization code flow for authentication.</p> </li> </ul>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "authenticationConfiguration": {
+                    "target": "com.amazonaws.qbusiness#DataAccessorAuthenticationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The specific authentication configuration based on the authentication type.</p>"
+                    }
+                },
+                "externalIds": {
+                    "target": "com.amazonaws.qbusiness#DataAccessorExternalIds",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of external identifiers associated with this authentication configuration. These are used to correlate the data accessor with external systems.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains the authentication configuration details for a data accessor. This structure defines how the ISV authenticates when accessing data through the data accessor.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#DataAccessorAuthenticationType": {
+            "type": "enum",
+            "members": {
+                "AWS_IAM_IDC_TTI": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AWS_IAM_IDC_TTI"
+                    }
+                },
+                "AWS_IAM_IDC_AUTH_CODE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AWS_IAM_IDC_AUTH_CODE"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The type of authentication mechanism used by the data accessor.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#DataAccessorExternalId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1000
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]*$"
+            }
+        },
+        "com.amazonaws.qbusiness#DataAccessorExternalIds": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#DataAccessorExternalId"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#DataAccessorId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 36,
+                    "max": 36
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{35}$"
+            }
+        },
+        "com.amazonaws.qbusiness#DataAccessorIdcTrustedTokenIssuerConfiguration": {
+            "type": "structure",
+            "members": {
+                "idcTrustedTokenIssuerArn": {
+                    "target": "com.amazonaws.qbusiness#IdcTrustedTokenIssuerArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM Identity Center Trusted Token Issuer that will be used for authentication.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration details for IAM Identity Center Trusted Token Issuer (TTI) authentication.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#DataAccessorName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 100
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]*$",
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DataAccessorResource": {
+            "type": "resource",
+            "identifiers": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId"
+                },
+                "dataAccessorId": {
+                    "target": "com.amazonaws.qbusiness#DataAccessorId"
+                }
+            },
+            "create": {
+                "target": "com.amazonaws.qbusiness#CreateDataAccessor"
+            },
+            "read": {
+                "target": "com.amazonaws.qbusiness#GetDataAccessor"
+            },
+            "update": {
+                "target": "com.amazonaws.qbusiness#UpdateDataAccessor"
+            },
+            "delete": {
+                "target": "com.amazonaws.qbusiness#DeleteDataAccessor"
+            },
+            "list": {
+                "target": "com.amazonaws.qbusiness#ListDataAccessors"
+            },
+            "traits": {
+                "aws.cloudformation#cfnResource": {
+                    "name": "DataAccessor"
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#DataAccessors": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#DataAccessor"
+            }
+        },
+        "com.amazonaws.qbusiness#DataSource": {
+            "type": "structure",
+            "members": {
+                "displayName": {
+                    "target": "com.amazonaws.qbusiness#DataSourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Amazon Q Business data source.</p>"
+                    }
+                },
+                "dataSourceId": {
+                    "target": "com.amazonaws.qbusiness#DataSourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business data source.</p>"
+                    }
+                },
+                "type": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the Amazon Q Business data source.</p>"
+                    }
+                },
+                "createdAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Unix timestamp when the Amazon Q Business data source was created.</p>"
+                    }
+                },
+                "updatedAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Unix timestamp when the Amazon Q Business data source was last updated. </p>"
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.qbusiness#DataSourceStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status of the Amazon Q Business data source.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A data source in an Amazon Q Business application.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#DataSourceArn": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 1284
+                },
+                "smithy.api#pattern": "^arn:[a-z0-9-\\.]{1,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}$"
+            }
+        },
+        "com.amazonaws.qbusiness#DataSourceConfiguration": {
+            "type": "document",
+            "traits": {
+                "smithy.api#documentation": "<p>Provides the configuration information for an Amazon Q Business data source.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#DataSourceId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 36,
+                    "max": 36
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{35}$"
+            }
+        },
+        "com.amazonaws.qbusiness#DataSourceIds": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#DataSourceId"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#DataSourceName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1000
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]*$"
+            }
+        },
+        "com.amazonaws.qbusiness#DataSourceResource": {
+            "type": "resource",
+            "identifiers": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId"
+                },
+                "indexId": {
+                    "target": "com.amazonaws.qbusiness#IndexId"
+                },
+                "dataSourceId": {
+                    "target": "com.amazonaws.qbusiness#DataSourceId"
+                }
+            },
+            "create": {
+                "target": "com.amazonaws.qbusiness#CreateDataSource"
+            },
+            "read": {
+                "target": "com.amazonaws.qbusiness#GetDataSource"
+            },
+            "update": {
+                "target": "com.amazonaws.qbusiness#UpdateDataSource"
+            },
+            "delete": {
+                "target": "com.amazonaws.qbusiness#DeleteDataSource"
+            },
+            "list": {
+                "target": "com.amazonaws.qbusiness#ListDataSources"
+            },
+            "traits": {
+                "aws.cloudformation#cfnResource": {
+                    "name": "DataSource"
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#DataSourceStatus": {
+            "type": "enum",
+            "members": {
+                "PENDING_CREATION": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PENDING_CREATION"
+                    }
+                },
+                "CREATING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CREATING"
+                    }
+                },
+                "ACTIVE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ACTIVE"
+                    }
+                },
+                "DELETING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETING"
+                    }
+                },
+                "FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FAILED"
+                    }
+                },
+                "UPDATING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "UPDATING"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#DataSourceSyncJob": {
+            "type": "structure",
+            "members": {
+                "executionId": {
+                    "target": "com.amazonaws.qbusiness#ExecutionId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of a data source synchronization job.</p>"
+                    }
+                },
+                "startTime": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Unix time stamp when the data source synchronization job started.</p>"
+                    }
+                },
+                "endTime": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Unix timestamp when the synchronization job completed.</p>"
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.qbusiness#DataSourceSyncJobStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status of the synchronization job. When the <code>Status</code> field is set to <code>SUCCEEDED</code>, the synchronization job is done. If the status code is <code>FAILED</code>, the <code>ErrorCode</code> and <code>ErrorMessage</code> fields give you the reason for the failure.</p>"
+                    }
+                },
+                "error": {
+                    "target": "com.amazonaws.qbusiness#ErrorDetail",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the <code>Status</code> field is set to <code>FAILED</code>, the <code>ErrorCode</code> field indicates the reason the synchronization failed. </p>"
+                    }
+                },
+                "dataSourceErrorCode": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the reason that the synchronization failed is due to an error with the underlying data source, this field contains a code that identifies the error.</p>"
+                    }
+                },
+                "metrics": {
+                    "target": "com.amazonaws.qbusiness#DataSourceSyncJobMetrics",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Maps a batch delete document request to a specific data source sync job. This is optional and should only be supplied when documents are deleted by a data source connector.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides information about an Amazon Q Business data source connector synchronization job.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#DataSourceSyncJobMetrics": {
+            "type": "structure",
+            "members": {
+                "documentsAdded": {
+                    "target": "com.amazonaws.qbusiness#MetricValue",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current count of documents added from the data source during the data source sync.</p>"
+                    }
+                },
+                "documentsModified": {
+                    "target": "com.amazonaws.qbusiness#MetricValue",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current count of documents modified in the data source during the data source sync.</p>"
+                    }
+                },
+                "documentsDeleted": {
+                    "target": "com.amazonaws.qbusiness#MetricValue",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current count of documents deleted from the data source during the data source sync.</p>"
+                    }
+                },
+                "documentsFailed": {
+                    "target": "com.amazonaws.qbusiness#MetricValue",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current count of documents that failed to sync from the data source during the data source sync.</p>"
+                    }
+                },
+                "documentsScanned": {
+                    "target": "com.amazonaws.qbusiness#MetricValue",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current count of documents crawled by the ongoing sync job in the data source.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Maps a batch delete document request to a specific Amazon Q Business data source connector sync job.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#DataSourceSyncJobStatus": {
+            "type": "enum",
+            "members": {
+                "FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FAILED"
+                    }
+                },
+                "SUCCEEDED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SUCCEEDED"
+                    }
+                },
+                "SYNCING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SYNCING"
+                    }
+                },
+                "INCOMPLETE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "INCOMPLETE"
+                    }
+                },
+                "STOPPING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "STOPPING"
+                    }
+                },
+                "ABORTED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ABORTED"
+                    }
+                },
+                "SYNCING_INDEXING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SYNCING_INDEXING"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#DataSourceSyncJobs": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#DataSourceSyncJob"
+            }
+        },
+        "com.amazonaws.qbusiness#DataSourceUserId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1024
+                },
+                "smithy.api#pattern": "^\\P{C}*$"
+            }
+        },
+        "com.amazonaws.qbusiness#DataSourceVpcConfiguration": {
+            "type": "structure",
+            "members": {
+                "subnetIds": {
+                    "target": "com.amazonaws.qbusiness#SubnetIds",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of identifiers for subnets within your Amazon VPC. The subnets should be able to connect to each other in the VPC, and they should have outgoing access to the Internet through a NAT device.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "securityGroupIds": {
+                    "target": "com.amazonaws.qbusiness#SecurityGroupIds",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of identifiers of security groups within your Amazon VPC. The security groups should enable Amazon Q Business to connect to the data source.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides configuration information needed to connect to an Amazon VPC (Virtual Private Cloud).</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#DataSources": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#DataSource"
+            }
+        },
+        "com.amazonaws.qbusiness#DateAttributeBoostingConfiguration": {
+            "type": "structure",
+            "members": {
+                "boostingLevel": {
+                    "target": "com.amazonaws.qbusiness#DocumentAttributeBoostingLevel",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the priority tier ranking of boosting applied to document attributes. For version 2, this parameter indicates the relative ranking between boosted fields (ONE being highest priority, TWO being second highest, etc.) and determines the order in which attributes influence document ranking in search results. For version 1, this parameter specifies the boosting intensity. For version 2, boosting intensity (VERY HIGH, HIGH, MEDIUM, LOW, NONE) are not supported. Note that in version 2, you are not allowed to boost on only one field and make this value TWO.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "boostingDurationInSeconds": {
+                    "target": "com.amazonaws.qbusiness#BoostingDurationInSeconds",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the duration, in seconds, of a boost applies to a <code>DATE</code> type document attribute.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides information on boosting <code>DATE</code> type document attributes.</p> <p>For more information on how boosting document attributes work in Amazon Q Business, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/business-use-dg/metadata-boosting.html\">Boosting using document attributes</a>.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteApplication": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#DeleteApplicationRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#DeleteApplicationResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#requiredActions": [
+                    "qbusiness:GetApplication",
+                    "kms:RetireGrant",
+                    "sso:DeleteApplication"
+                ],
+                "smithy.api#documentation": "<p>Deletes an Amazon Q Business application.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}",
+                    "method": "DELETE"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteApplicationRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteApplicationResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteAttachment": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#DeleteAttachmentRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#DeleteAttachmentResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#LicenseNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes an attachment associated with a specific Amazon Q Business conversation.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/conversations/{conversationId}/attachments/{attachmentId}",
+                    "method": "DELETE"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteAttachmentRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier for the Amazon Q Business application environment.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "conversationId": {
+                    "target": "com.amazonaws.qbusiness#ConversationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the conversation.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "attachmentId": {
+                    "target": "com.amazonaws.qbusiness#AttachmentId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier for the attachment.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "userId": {
+                    "target": "com.amazonaws.qbusiness#UserId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the user involved in the conversation.</p>",
+                        "smithy.api#httpQuery": "userId"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteAttachmentResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteChatControlsConfiguration": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#DeleteChatControlsConfigurationRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#DeleteChatControlsConfigurationResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes chat controls configured for an existing Amazon Q Business application.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/chatcontrols",
+                    "method": "DELETE",
+                    "code": 200
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteChatControlsConfigurationRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the application the chat controls have been configured for.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteChatControlsConfigurationResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteChatResponseConfiguration": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#DeleteChatResponseConfigurationRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#DeleteChatResponseConfigurationResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#iamAction": {
+                    "requiredActions": [
+                        "qbusiness:GetChatResponseConfiguration"
+                    ]
+                },
+                "smithy.api#documentation": "<p>Deletes a specified chat response configuration from an Amazon Q Business application.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/applications/{applicationId}/chatresponseconfigurations/{chatResponseConfigurationId}"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteChatResponseConfigurationRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of theAmazon Q Business application from which to delete the chat response configuration.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "chatResponseConfigurationId": {
+                    "target": "com.amazonaws.qbusiness#ChatResponseConfigurationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the chat response configuration to delete from the specified application. </p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteChatResponseConfigurationResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteConversation": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#DeleteConversationRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#DeleteConversationResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#LicenseNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes an Amazon Q Business web experience conversation.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/conversations/{conversationId}",
+                    "method": "DELETE"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteConversationRequest": {
+            "type": "structure",
+            "members": {
+                "conversationId": {
+                    "target": "com.amazonaws.qbusiness#ConversationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business web experience conversation being deleted.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application associated with the conversation.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "userId": {
+                    "target": "com.amazonaws.qbusiness#UserId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the user who is deleting the conversation.</p>",
+                        "smithy.api#httpQuery": "userId"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteConversationResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteDataAccessor": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#DeleteDataAccessorRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#DeleteDataAccessorResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#requiredActions": [
+                    "qbusiness:GetDataAccessor"
+                ],
+                "smithy.api#documentation": "<p>Deletes a specified data accessor. This operation permanently removes the data accessor and its associated IAM Identity Center application. Any access granted to the ISV through this data accessor will be revoked.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/dataaccessors/{dataAccessorId}",
+                    "method": "DELETE"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteDataAccessorRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the Amazon Q Business application.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "dataAccessorId": {
+                    "target": "com.amazonaws.qbusiness#DataAccessorId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the data accessor to delete.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteDataAccessorResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteDataSource": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#DeleteDataSourceRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#DeleteDataSourceResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#requiredActions": [
+                    "qbusiness:GetDataSource"
+                ],
+                "smithy.api#documentation": "<p>Deletes an Amazon Q Business data source connector. While the data source is being deleted, the <code>Status</code> field returned by a call to the <code>DescribeDataSource</code> API is set to <code>DELETING</code>. </p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/indices/{indexId}/datasources/{dataSourceId}",
+                    "method": "DELETE"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteDataSourceRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application used with the data source connector.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "indexId": {
+                    "target": "com.amazonaws.qbusiness#IndexId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the index used with the data source connector.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "dataSourceId": {
+                    "target": "com.amazonaws.qbusiness#DataSourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the data source connector that you want to delete. </p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteDataSourceResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteDocument": {
+            "type": "structure",
+            "members": {
+                "documentId": {
+                    "target": "com.amazonaws.qbusiness#DocumentId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the deleted document.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A document deleted from an Amazon Q Business data source connector.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteDocuments": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#DeleteDocument"
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteGroup": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#DeleteGroupRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#DeleteGroupResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes a group so that all users and sub groups that belong to the group can no longer access documents only available to that group. For example, after deleting the group \"Summer Interns\", all interns who belonged to that group no longer see intern-only documents in their chat results. </p> <p>If you want to delete, update, or replace users or sub groups of a group, you need to use the <code>PutGroup</code> operation. For example, if a user in the group \"Engineering\" leaves the engineering team and another user takes their place, you provide an updated list of users or sub groups that belong to the \"Engineering\" group when calling <code>PutGroup</code>.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/applications/{applicationId}/indices/{indexId}/groups/{groupName}"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteGroupRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the application in which the group mapping belongs.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "indexId": {
+                    "target": "com.amazonaws.qbusiness#IndexId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the index you want to delete the group from.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "groupName": {
+                    "target": "com.amazonaws.qbusiness#GroupName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the group you want to delete.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "dataSourceId": {
+                    "target": "com.amazonaws.qbusiness#DataSourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the data source linked to the group</p> <p>A group can be tied to multiple data sources. You can delete a group from accessing documents in a certain data source. For example, the groups \"Research\", \"Engineering\", and \"Sales and Marketing\" are all tied to the company's documents stored in the data sources Confluence and Salesforce. You want to delete \"Research\" and \"Engineering\" groups from Salesforce, so that these groups cannot access customer-related documents stored in Salesforce. Only \"Sales and Marketing\" should access documents in the Salesforce data source.</p>",
+                        "smithy.api#httpQuery": "dataSourceId"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteGroupResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteIndex": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#DeleteIndexRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#DeleteIndexResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#requiredActions": [
+                    "qbusiness:GetIndex"
+                ],
+                "smithy.api#documentation": "<p>Deletes an Amazon Q Business index.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/indices/{indexId}",
+                    "method": "DELETE"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteIndexRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application the Amazon Q Business index is linked to.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "indexId": {
+                    "target": "com.amazonaws.qbusiness#IndexId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business index.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteIndexResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeletePlugin": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#DeletePluginRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#DeletePluginResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#requiredActions": [
+                    "qbusiness:GetPlugin"
+                ],
+                "smithy.api#documentation": "<p>Deletes an Amazon Q Business plugin.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/applications/{applicationId}/plugins/{pluginId}"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeletePluginRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier the application attached to the Amazon Q Business plugin.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "pluginId": {
+                    "target": "com.amazonaws.qbusiness#PluginId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the plugin being deleted.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeletePluginResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteRetriever": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#DeleteRetrieverRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#DeleteRetrieverResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#requiredActions": [
+                    "qbusiness:GetRetriever"
+                ],
+                "smithy.api#documentation": "<p>Deletes the retriever used by an Amazon Q Business application.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/applications/{applicationId}/retrievers/{retrieverId}"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteRetrieverRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application using the retriever.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "retrieverId": {
+                    "target": "com.amazonaws.qbusiness#RetrieverId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the retriever being deleted.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteRetrieverResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteUser": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#DeleteUserRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#DeleteUserResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes a user by email id.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/applications/{applicationId}/users/{userId}"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteUserRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the application from which the user is being deleted.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "userId": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The user email being deleted.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteUserResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteWebExperience": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#DeleteWebExperienceRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#DeleteWebExperienceResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#requiredActions": [
+                    "qbusiness:GetWebExperience"
+                ],
+                "smithy.api#documentation": "<p>Deletes an Amazon Q Business web experience.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/experiences/{webExperienceId}",
+                    "method": "DELETE"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteWebExperienceRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application linked to the Amazon Q Business web experience.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "webExperienceId": {
+                    "target": "com.amazonaws.qbusiness#WebExperienceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business web experience being deleted.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DeleteWebExperienceResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#Description": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 1000
+                },
+                "smithy.api#pattern": "^[\\s\\S]*$"
+            }
+        },
+        "com.amazonaws.qbusiness#DisassociatePermission": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#DisassociatePermissionRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#DisassociatePermissionResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Removes a permission policy from a Amazon Q Business application, revoking the cross-account access that was previously granted to an ISV. This operation deletes the specified policy statement from the application's permission policy.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/policy/{statementId}",
+                    "method": "DELETE"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DisassociatePermissionRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the Amazon Q Business application.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "statementId": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The statement ID of the permission to remove.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DisassociatePermissionResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#DisplayName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 100
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#Document": {
+            "type": "structure",
+            "members": {
+                "id": {
+                    "target": "com.amazonaws.qbusiness#DocumentId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the document.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "attributes": {
+                    "target": "com.amazonaws.qbusiness#DocumentAttributes",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Custom attributes to apply to the document for refining Amazon Q Business web experience responses.</p>"
+                    }
+                },
+                "content": {
+                    "target": "com.amazonaws.qbusiness#DocumentContent",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The contents of the document.</p>"
+                    }
+                },
+                "contentType": {
+                    "target": "com.amazonaws.qbusiness#ContentType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The file type of the document in the Blob field.</p> <p>If you want to index snippets or subsets of HTML documents instead of the entirety of the HTML documents, you add the <code>HTML</code> start and closing tags (<code>&lt;HTML&gt;content&lt;/HTML&gt;</code>) around the content.</p>"
+                    }
+                },
+                "title": {
+                    "target": "com.amazonaws.qbusiness#Title",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The title of the document.</p>"
+                    }
+                },
+                "accessConfiguration": {
+                    "target": "com.amazonaws.qbusiness#AccessConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configuration information for access permission to a document.</p>"
+                    }
+                },
+                "documentEnrichmentConfiguration": {
+                    "target": "com.amazonaws.qbusiness#DocumentEnrichmentConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configuration information for altering document metadata and content during the document ingestion process.</p>"
+                    }
+                },
+                "mediaExtractionConfiguration": {
+                    "target": "com.amazonaws.qbusiness#MediaExtractionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configuration for extracting information from media in the document.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A document in an Amazon Q Business application.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#DocumentAcl": {
+            "type": "structure",
+            "members": {
+                "allowlist": {
+                    "target": "com.amazonaws.qbusiness#DocumentAclMembership",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The allowlist conditions for the document. Users or groups matching these conditions are granted access to the document.</p>"
+                    }
+                },
+                "denyList": {
+                    "target": "com.amazonaws.qbusiness#DocumentAclMembership",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The denylist conditions for the document. Users or groups matching these conditions are denied access to the document, overriding allowlist permissions.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents the Access Control List (ACL) for a document, containing both allowlist and denylist conditions.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#DocumentAclCondition": {
+            "type": "structure",
+            "members": {
+                "memberRelation": {
+                    "target": "com.amazonaws.qbusiness#MemberRelation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The logical relation between members in the condition, determining how multiple user or group conditions are combined.</p>"
+                    }
+                },
+                "users": {
+                    "target": "com.amazonaws.qbusiness#DocumentAclUsers",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An array of user identifiers that this condition applies to. Users listed here are subject to the access rule defined by this condition.</p>"
+                    }
+                },
+                "groups": {
+                    "target": "com.amazonaws.qbusiness#DocumentAclGroups",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An array of group identifiers that this condition applies to. Groups listed here are subject to the access rule defined by this condition.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a condition in the document's ACL, specifying access rules for users and groups.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#DocumentAclConditions": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#DocumentAclCondition"
+            }
+        },
+        "com.amazonaws.qbusiness#DocumentAclGroup": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "com.amazonaws.qbusiness#GroupName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the group in the document's ACL. This is used to identify the group when applying access rules.</p>"
+                    }
+                },
+                "type": {
+                    "target": "com.amazonaws.qbusiness#MembershipType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the group. This indicates the scope of the group's applicability in access control.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a group in the document's ACL, used to define access permissions for multiple users collectively.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#DocumentAclGroups": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#DocumentAclGroup"
+            }
+        },
+        "com.amazonaws.qbusiness#DocumentAclMembership": {
+            "type": "structure",
+            "members": {
+                "memberRelation": {
+                    "target": "com.amazonaws.qbusiness#MemberRelation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The logical relation between members in the membership rule, determining how multiple conditions are combined.</p>"
+                    }
+                },
+                "conditions": {
+                    "target": "com.amazonaws.qbusiness#DocumentAclConditions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An array of conditions that define the membership rules. Each condition specifies criteria for users or groups to be included in this membership.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents membership rules in the document's ACL, defining how users or groups are associated with access permissions.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#DocumentAclUser": {
+            "type": "structure",
+            "members": {
+                "id": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the user in the document's ACL. This is used to identify the user when applying access rules.</p>"
+                    }
+                },
+                "type": {
+                    "target": "com.amazonaws.qbusiness#MembershipType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the user. This indicates the scope of the user's applicability in access control.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a user in the document's ACL, used to define access permissions for individual users.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#DocumentAclUsers": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#DocumentAclUser"
+            }
+        },
+        "com.amazonaws.qbusiness#DocumentAttribute": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "com.amazonaws.qbusiness#DocumentAttributeKey",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier for the attribute.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "value": {
+                    "target": "com.amazonaws.qbusiness#DocumentAttributeValue",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The value of the attribute. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A document attribute or metadata field.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#DocumentAttributeBoostingConfiguration": {
+            "type": "union",
+            "members": {
+                "numberConfiguration": {
+                    "target": "com.amazonaws.qbusiness#NumberAttributeBoostingConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Provides information on boosting <code>NUMBER</code> type document attributes.</p> <p> <code>NUMBER</code> attributes are not supported when using <code>NativeIndexConfiguration</code> version 2, which focuses on <code>DATE</code> attributes for recency and <code>STRING</code> attributes for source prioritization.</p>"
+                    }
+                },
+                "stringConfiguration": {
+                    "target": "com.amazonaws.qbusiness#StringAttributeBoostingConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Provides information on boosting <code>STRING</code> type document attributes.</p> <p>Version 2 assigns priority tiers to <code>STRING</code> attributes, establishing clear hierarchical relationships with other boosted attributes.</p>"
+                    }
+                },
+                "dateConfiguration": {
+                    "target": "com.amazonaws.qbusiness#DateAttributeBoostingConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Provides information on boosting <code>DATE</code> type document attributes.</p> <p>Version 2 assigns priority tiers to <code>DATE</code> attributes, establishing clear hierarchical relationships with other boosted attributes.</p>"
+                    }
+                },
+                "stringListConfiguration": {
+                    "target": "com.amazonaws.qbusiness#StringListAttributeBoostingConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Provides information on boosting <code>STRING_LIST</code> type document attributes.</p> <p> <code>STRING_LIST</code> attributes are not supported when using <code>NativeIndexConfiguration</code> version 2, which focuses on <code>DATE</code> attributes for recency and <code>STRING</code> attributes for source prioritization.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides information on boosting supported Amazon Q Business document attribute types. When an end user chat query matches document attributes that have been boosted, Amazon Q Business prioritizes generating responses from content that matches the boosted document attributes.</p> <p>In version 2, boosting uses numeric values (ONE, TWO) to indicate priority tiers that establish clear hierarchical relationships between boosted attributes. This allows for more precise control over how different attributes influence search results.</p> <note> <p>For <code>STRING</code> and <code>STRING_LIST</code> type document attributes to be used for boosting on the console and the API, they must be enabled for search using the <a href=\"https://docs.aws.amazon.com/amazonq/latest/api-reference/API_DocumentAttributeConfiguration.html\">DocumentAttributeConfiguration</a> object of the <a href=\"https://docs.aws.amazon.com/amazonq/latest/api-reference/API_UpdateIndex.html\">UpdateIndex</a> API. If you haven't enabled searching on these attributes, you can't boost attributes of these data types on either the console or the API.</p> </note> <p>For more information on how boosting document attributes work in Amazon Q Business, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/business-use-dg/metadata-boosting.html\">Boosting using document attributes</a>.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#DocumentAttributeBoostingLevel": {
+            "type": "enum",
+            "members": {
+                "NONE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NONE"
+                    }
+                },
+                "LOW": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "LOW"
+                    }
+                },
+                "MEDIUM": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MEDIUM"
+                    }
+                },
+                "HIGH": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "HIGH"
+                    }
+                },
+                "VERY_HIGH": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "VERY_HIGH"
+                    }
+                },
+                "ONE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ONE"
+                    }
+                },
+                "TWO": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "TWO"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#DocumentAttributeBoostingOverrideMap": {
+            "type": "map",
+            "key": {
+                "target": "com.amazonaws.qbusiness#DocumentAttributeKey"
+            },
+            "value": {
+                "target": "com.amazonaws.qbusiness#DocumentAttributeBoostingConfiguration"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#DocumentAttributeCondition": {
+            "type": "structure",
+            "members": {
+                "key": {
+                    "target": "com.amazonaws.qbusiness#DocumentAttributeKey",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the document attribute used for the condition.</p> <p>For example, 'Source_URI' could be an identifier for the attribute or metadata field that contains source URIs associated with the documents.</p> <p>Amazon Q Business currently doesn't support <code>_document_body</code> as an attribute key used for the condition.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "operator": {
+                    "target": "com.amazonaws.qbusiness#DocumentEnrichmentConditionOperator",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the document attribute used for the condition.</p> <p>For example, 'Source_URI' could be an identifier for the attribute or metadata field that contains source URIs associated with the documents.</p> <p>Amazon Q Business currently does not support <code>_document_body</code> as an attribute key used for the condition.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "value": {
+                    "target": "com.amazonaws.qbusiness#DocumentAttributeValue"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The condition used for the target document attribute or metadata field when ingesting documents into Amazon Q Business. You use this with <a href=\"https://docs.aws.amazon.com/amazonq/latest/api-reference/API_DocumentAttributeTarget.html\"> <code>DocumentAttributeTarget</code> </a> to apply the condition.</p> <p>For example, you can create the 'Department' target field and have it prefill department names associated with the documents based on information in the 'Source_URI' field. Set the condition that if the 'Source_URI' field contains 'financial' in its URI value, then prefill the target field 'Department' with the target value 'Finance' for the document.</p> <p>Amazon Q Business can't create a target field if it has not already been created as an index field. After you create your index field, you can create a document metadata field using <code>DocumentAttributeTarget</code>. Amazon Q Business then will map your newly created metadata field to your index field.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#DocumentAttributeConfiguration": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "com.amazonaws.qbusiness#DocumentMetadataConfigurationName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the document attribute.</p>"
+                    }
+                },
+                "type": {
+                    "target": "com.amazonaws.qbusiness#AttributeType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of document attribute.</p>"
+                    }
+                },
+                "search": {
+                    "target": "com.amazonaws.qbusiness#Status",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about whether the document attribute can be used by an end user to search for information on their web experience.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration information for document attributes. Document attributes are metadata or fields associated with your documents. For example, the company department name associated with each document.</p> <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/business-use-dg/doc-attributes.html\">Understanding document attributes</a>.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#DocumentAttributeConfigurations": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#DocumentAttributeConfiguration"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 500
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#DocumentAttributeKey": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 200
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9_][a-zA-Z0-9_-]*$"
+            }
+        },
+        "com.amazonaws.qbusiness#DocumentAttributeStringListValue": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#String"
+            }
+        },
+        "com.amazonaws.qbusiness#DocumentAttributeStringValue": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "max": 2048
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#DocumentAttributeTarget": {
+            "type": "structure",
+            "members": {
+                "key": {
+                    "target": "com.amazonaws.qbusiness#DocumentAttributeKey",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the target document attribute or metadata field. For example, 'Department' could be an identifier for the target attribute or metadata field that includes the department names associated with the documents.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "value": {
+                    "target": "com.amazonaws.qbusiness#DocumentAttributeValue"
+                },
+                "attributeValueOperator": {
+                    "target": "com.amazonaws.qbusiness#AttributeValueOperator",
+                    "traits": {
+                        "smithy.api#documentation": "<p> <code>TRUE</code> to delete the existing target value for your specified target attribute key. You cannot create a target value and set this to <code>TRUE</code>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The target document attribute or metadata field you want to alter when ingesting documents into Amazon Q Business.</p> <p>For example, you can delete all customer identification numbers associated with the documents, stored in the document metadata field called 'Customer_ID' by setting the target key as 'Customer_ID' and the deletion flag to <code>TRUE</code>. This removes all customer ID values in the field 'Customer_ID'. This would scrub personally identifiable information from each document's metadata.</p> <p>Amazon Q Business can't create a target field if it has not already been created as an index field. After you create your index field, you can create a document metadata field using <a href=\"https://docs.aws.amazon.com/amazonq/latest/api-reference/API_DocumentAttributeTarget.html\"> <code>DocumentAttributeTarget</code> </a>. Amazon Q Business will then map your newly created document attribute to your index field.</p> <p>You can also use this with <a href=\"https://docs.aws.amazon.com/amazonq/latest/api-reference/API_DocumentAttributeCondition.html\"> <code>DocumentAttributeCondition</code> </a>.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#DocumentAttributeValue": {
+            "type": "union",
+            "members": {
+                "stringValue": {
+                    "target": "com.amazonaws.qbusiness#DocumentAttributeStringValue",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A string.</p>",
+                        "smithy.api#length": {
+                            "max": 2048
+                        }
+                    }
+                },
+                "stringListValue": {
+                    "target": "com.amazonaws.qbusiness#DocumentAttributeStringListValue",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of strings.</p>"
+                    }
+                },
+                "longValue": {
+                    "target": "com.amazonaws.qbusiness#Long",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A long integer value. </p>"
+                    }
+                },
+                "dateValue": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A date expressed as an ISO 8601 string.</p> <p>It's important for the time zone to be included in the ISO 8601 date-time format. For example, 2012-03-25T12:30:10+01:00 is the ISO 8601 date-time format for March 25th 2012 at 12:30PM (plus 10 seconds) in Central European Time. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The value of a document attribute. You can only provide one value for a document attribute.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#DocumentAttributes": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#DocumentAttribute"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 500
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#DocumentContent": {
+            "type": "union",
+            "members": {
+                "blob": {
+                    "target": "smithy.api#Blob",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The contents of the document. Documents passed to the <code>blob</code> parameter must be base64 encoded. Your code might not need to encode the document file bytes if you're using an Amazon Web Services SDK to call Amazon Q Business APIs. If you are calling the Amazon Q Business endpoint directly using REST, you must base64 encode the contents before sending.</p>"
+                    }
+                },
+                "s3": {
+                    "target": "com.amazonaws.qbusiness#S3",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The path to the document in an Amazon S3 bucket.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The contents of a document.</p> <note> <p>Documents have size limitations. The maximum file size for a document is 50 MB. The maximum amount of text that can be extracted from a single document is 5 MB. For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/doc-types.html\">Supported document formats in Amazon Q Business</a>.</p> </note>"
+            }
+        },
+        "com.amazonaws.qbusiness#DocumentContentOperator": {
+            "type": "enum",
+            "members": {
+                "DELETE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETE"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#DocumentDetailList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#DocumentDetails"
+            }
+        },
+        "com.amazonaws.qbusiness#DocumentDetails": {
+            "type": "structure",
+            "members": {
+                "documentId": {
+                    "target": "com.amazonaws.qbusiness#DocumentId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the document.</p>"
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.qbusiness#DocumentStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current status of the document.</p>"
+                    }
+                },
+                "error": {
+                    "target": "com.amazonaws.qbusiness#ErrorDetail",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An error message associated with the document.</p>"
+                    }
+                },
+                "createdAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp for when the document was created.</p>"
+                    }
+                },
+                "updatedAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp for when the document was last updated.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The details of a document within an Amazon Q Business index.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#DocumentEnrichmentConditionOperator": {
+            "type": "enum",
+            "members": {
+                "GREATER_THAN": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "GREATER_THAN"
+                    }
+                },
+                "GREATER_THAN_OR_EQUALS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "GREATER_THAN_OR_EQUALS"
+                    }
+                },
+                "LESS_THAN": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "LESS_THAN"
+                    }
+                },
+                "LESS_THAN_OR_EQUALS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "LESS_THAN_OR_EQUALS"
+                    }
+                },
+                "EQUALS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "EQUALS"
+                    }
+                },
+                "NOT_EQUALS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NOT_EQUALS"
+                    }
+                },
+                "CONTAINS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CONTAINS"
+                    }
+                },
+                "NOT_CONTAINS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NOT_CONTAINS"
+                    }
+                },
+                "EXISTS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "EXISTS"
+                    }
+                },
+                "NOT_EXISTS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NOT_EXISTS"
+                    }
+                },
+                "BEGINS_WITH": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "BEGINS_WITH"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#DocumentEnrichmentConfiguration": {
+            "type": "structure",
+            "members": {
+                "inlineConfigurations": {
+                    "target": "com.amazonaws.qbusiness#InlineDocumentEnrichmentConfigurations",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configuration information to alter document attributes or metadata fields and content when ingesting documents into Amazon Q Business.</p>"
+                    }
+                },
+                "preExtractionHookConfiguration": {
+                    "target": "com.amazonaws.qbusiness#HookConfiguration"
+                },
+                "postExtractionHookConfiguration": {
+                    "target": "com.amazonaws.qbusiness#HookConfiguration"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides the configuration information for altering document metadata and content during the document ingestion process.</p> <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/business-use-dg/custom-document-enrichment.html\">Custom document enrichment</a>.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#DocumentId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1825
+                },
+                "smithy.api#pattern": "^\\P{C}*$"
+            }
+        },
+        "com.amazonaws.qbusiness#DocumentMetadataConfigurationName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 30
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9_][a-zA-Z0-9_-]*$"
+            }
+        },
+        "com.amazonaws.qbusiness#DocumentStatus": {
+            "type": "enum",
+            "members": {
+                "RECEIVED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "RECEIVED"
+                    }
+                },
+                "PROCESSING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PROCESSING"
+                    }
+                },
+                "INDEXED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "INDEXED"
+                    }
+                },
+                "UPDATED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "UPDATED"
+                    }
+                },
+                "FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FAILED"
+                    }
+                },
+                "DELETING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETING"
+                    }
+                },
+                "DELETED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETED"
+                    }
+                },
+                "DOCUMENT_FAILED_TO_INDEX": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DOCUMENT_FAILED_TO_INDEX"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#Documents": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#Document"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 10
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#EligibleDataSource": {
+            "type": "structure",
+            "members": {
+                "indexId": {
+                    "target": "com.amazonaws.qbusiness#IndexId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the index the data source is attached to.</p>"
+                    }
+                },
+                "dataSourceId": {
+                    "target": "com.amazonaws.qbusiness#DataSourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the data source.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The identifier of the data source Amazon Q Business will generate responses from.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#EligibleDataSources": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#EligibleDataSource"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "max": 5
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#EncryptionConfiguration": {
+            "type": "structure",
+            "members": {
+                "kmsKeyId": {
+                    "target": "com.amazonaws.qbusiness#KmsKeyId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the KMS key. Amazon Q Business doesn't support asymmetric keys.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides the identifier of the KMS key used to encrypt data indexed by Amazon Q Business. Amazon Q Business doesn't support asymmetric keys.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#EndOfInputEvent": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#documentation": "<p>The end of the streaming input for the <code>Chat</code> API.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#ErrorCode": {
+            "type": "enum",
+            "members": {
+                "INTERNAL_ERROR": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "InternalError"
+                    }
+                },
+                "INVALID_REQUEST": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "InvalidRequest"
+                    }
+                },
+                "RESOURCE_INACTIVE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ResourceInactive"
+                    }
+                },
+                "RESOURCE_NOT_FOUND": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ResourceNotFound"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#ErrorDetail": {
+            "type": "structure",
+            "members": {
+                "errorMessage": {
+                    "target": "com.amazonaws.qbusiness#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The message explaining the Amazon Q Business request error.</p>"
+                    }
+                },
+                "errorCode": {
+                    "target": "com.amazonaws.qbusiness#ErrorCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The code associated with the Amazon Q Business request error.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides information about a Amazon Q Business request error.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#ErrorMessage": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 2048
+                },
+                "smithy.api#pattern": "^[\\s\\S]*$"
+            }
+        },
+        "com.amazonaws.qbusiness#ExampleChatMessage": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "max": 350
+                },
+                "smithy.api#pattern": "^\\P{C}*$"
+            }
+        },
+        "com.amazonaws.qbusiness#ExampleChatMessages": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#ExampleChatMessage"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "max": 5
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#ExecutionId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 36,
+                    "max": 36
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{35}$"
+            }
+        },
+        "com.amazonaws.qbusiness#ExpertQ": {
+            "type": "service",
+            "version": "2023-11-27",
+            "operations": [
+                {
+                    "target": "com.amazonaws.qbusiness#AssociatePermission"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#BatchDeleteDocument"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#BatchPutDocument"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#CancelSubscription"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#Chat"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ChatSync"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#CheckDocumentAccess"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#CreateAnonymousWebExperienceUrl"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#CreateChatResponseConfiguration"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#CreateSubscription"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#CreateUser"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#DeleteAttachment"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#DeleteChatControlsConfiguration"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#DeleteChatResponseConfiguration"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#DeleteConversation"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#DeleteGroup"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#DeleteUser"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#DisassociatePermission"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#GetChatControlsConfiguration"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#GetChatResponseConfiguration"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#GetDocumentContent"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#GetGroup"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#GetMedia"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#GetPolicy"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#GetUser"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ListAttachments"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ListChatResponseConfigurations"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ListConversations"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ListDataSourceSyncJobs"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ListDocuments"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ListGroups"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ListMessages"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ListPluginActions"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ListPluginTypeActions"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ListPluginTypeMetadata"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ListSubscriptions"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ListTagsForResource"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#PutFeedback"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#PutGroup"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#SearchRelevantContent"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#StartDataSourceSyncJob"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#StopDataSourceSyncJob"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#TagResource"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#UntagResource"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#UpdateChatControlsConfiguration"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#UpdateChatResponseConfiguration"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#UpdateSubscription"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#UpdateUser"
+                }
+            ],
+            "resources": [
+                {
+                    "target": "com.amazonaws.qbusiness#ApplicationResource"
+                }
+            ],
+            "traits": {
+                "aws.api#service": {
+                    "sdkId": "QBusiness",
+                    "cloudFormationName": "QBusiness",
+                    "arnNamespace": "qbusiness",
+                    "cloudTrailEventSource": "qbusiness.amazonaws.com"
+                },
+                "aws.auth#sigv4": {
+                    "name": "qbusiness"
+                },
+                "aws.protocols#restJson1": {
+                    "http": [
+                        "h2",
+                        "http/1.1"
+                    ],
+                    "eventStreamHttp": [
+                        "h2"
+                    ]
+                },
+                "smithy.api#documentation": "<p>This is the <i>Amazon Q Business</i> API Reference. Amazon Q Business is a fully managed, generative-AI powered enterprise chat assistant that you can deploy within your organization. Amazon Q Business enhances employee productivity by supporting key tasks such as question-answering, knowledge discovery, writing email messages, summarizing text, drafting document outlines, and brainstorming ideas. Users ask questions of Amazon Q Business and get answers that are presented in a conversational manner. For an introduction to the service, see the <a href=\"https://docs.aws.amazon.com/amazonq/latest/business-use-dg/what-is.html\"> <i>Amazon Q Business User Guide</i> </a>.</p> <p>For an overview of the Amazon Q Business APIs, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/business-use-dg/api-ref.html#api-overview\">Overview of Amazon Q Business API operations</a>.</p> <p>For information about the IAM access control permissions you need to use this API, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/business-use-dg/iam-roles.html\">IAM roles for Amazon Q Business</a> in the <i>Amazon Q Business User Guide</i>.</p> <p>The following resources provide additional information about using the Amazon Q Business API:</p> <ul> <li> <p> <i> <a href=\"https://docs.aws.amazon.com/amazonq/latest/business-use-dg/setting-up.html\">Setting up for Amazon Q Business</a> </i> </p> </li> <li> <p> <i> <a href=\"https://awscli.amazonaws.com/v2/documentation/api/latest/reference/qbusiness/index.html\">Amazon Q Business CLI Reference</a> </i> </p> </li> <li> <p> <i> <a href=\"https://docs.aws.amazon.com/general/latest/gr/amazonq.html\">Amazon Web Services General Reference</a> </i> </p> </li> </ul>",
+                "smithy.api#title": "QBusiness",
+                "smithy.rules#endpointBdd": {
+                    "version": "1.1",
+                    "parameters": {
+                        "Region": {
+                            "builtIn": "AWS::Region",
+                            "required": false,
+                            "documentation": "The AWS region used to dispatch the request.",
+                            "type": "string"
+                        },
+                        "UseFIPS": {
+                            "builtIn": "AWS::UseFIPS",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+                            "type": "boolean"
+                        },
+                        "Endpoint": {
+                            "builtIn": "SDK::Endpoint",
+                            "required": false,
+                            "documentation": "Override the endpoint used to send this request",
+                            "type": "string"
+                        }
+                    },
+                    "conditions": [
+                        {
+                            "fn": "isSet",
+                            "argv": [
+                                {
+                                    "ref": "Endpoint"
+                                }
+                            ]
+                        },
+                        {
+                            "fn": "isSet",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                }
+                            ]
+                        },
+                        {
+                            "fn": "aws.partition",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                }
+                            ],
+                            "assign": "PartitionResult"
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "ref": "UseFIPS"
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "PartitionResult"
+                                        },
+                                        "supportsFIPS"
+                                    ]
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "PartitionResult"
+                                        },
+                                        "supportsDualStack"
+                                    ]
+                                },
+                                true
+                            ]
+                        }
+                    ],
+                    "results": [
+                        {
+                            "conditions": [],
+                            "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": {
+                                    "ref": "Endpoint"
+                                },
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://qbusiness-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "FIPS is enabled but this partition does not support FIPS",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://qbusiness.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://qbusiness-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://qbusiness.{Region}.{PartitionResult#dnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid Configuration: Missing Region",
+                            "type": "error"
+                        }
+                    ],
+                    "root": 2,
+                    "nodeCount": 9,
+                    "nodes": "/////wAAAAH/////AAAAAAAAAAkAAAADAAAAAQAAAAQF9eEIAAAAAgAAAAUF9eEIAAAAAwAAAAcAAAAGAAAABQX14QUF9eEHAAAABAAAAAgF9eEEAAAABQX14QMF9eEGAAAAAwX14QEF9eEC"
+                },
+                "smithy.rules#endpointRuleSet": {
+                    "version": "1.0",
+                    "parameters": {
+                        "Region": {
+                            "builtIn": "AWS::Region",
+                            "required": false,
+                            "documentation": "The AWS region used to dispatch the request.",
+                            "type": "string"
+                        },
+                        "UseFIPS": {
+                            "builtIn": "AWS::UseFIPS",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+                            "type": "boolean"
+                        },
+                        "Endpoint": {
+                            "builtIn": "SDK::Endpoint",
+                            "required": false,
+                            "documentation": "Override the endpoint used to send this request",
+                            "type": "string"
+                        }
+                    },
+                    "rules": [
+                        {
+                            "conditions": [
+                                {
+                                    "fn": "isSet",
+                                    "argv": [
+                                        {
+                                            "ref": "Endpoint"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "booleanEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "UseFIPS"
+                                                },
+                                                true
+                                            ]
+                                        }
+                                    ],
+                                    "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                                    "type": "error"
+                                },
+                                {
+                                    "conditions": [],
+                                    "endpoint": {
+                                        "url": {
+                                            "ref": "Endpoint"
+                                        },
+                                        "properties": {},
+                                        "headers": {}
+                                    },
+                                    "type": "endpoint"
+                                }
+                            ],
+                            "type": "tree"
+                        },
+                        {
+                            "conditions": [
+                                {
+                                    "fn": "isSet",
+                                    "argv": [
+                                        {
+                                            "ref": "Region"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "aws.partition",
+                                            "argv": [
+                                                {
+                                                    "ref": "Region"
+                                                }
+                                            ],
+                                            "assign": "PartitionResult"
+                                        }
+                                    ],
+                                    "rules": [
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        true,
+                                                        {
+                                                            "fn": "getAttr",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "PartitionResult"
+                                                                },
+                                                                "supportsDualStack"
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "endpoint": {
+                                                                        "url": "https://qbusiness-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                        "properties": {},
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                }
+                                                            ],
+                                                            "type": "tree"
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS is enabled but this partition does not support FIPS",
+                                                            "type": "error"
+                                                        }
+                                                    ],
+                                                    "type": "tree"
+                                                },
+                                                {
+                                                    "conditions": [],
+                                                    "endpoint": {
+                                                        "url": "https://qbusiness.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                        "properties": {},
+                                                        "headers": {}
+                                                    },
+                                                    "type": "endpoint"
+                                                }
+                                            ],
+                                            "type": "tree"
+                                        },
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseFIPS"
+                                                        },
+                                                        true
+                                                    ]
+                                                }
+                                            ],
+                                            "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "fn": "getAttr",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "PartitionResult"
+                                                                        },
+                                                                        "supportsFIPS"
+                                                                    ]
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [],
+                                                            "endpoint": {
+                                                                "url": "https://qbusiness-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        }
+                                                    ],
+                                                    "type": "tree"
+                                                },
+                                                {
+                                                    "conditions": [],
+                                                    "error": "FIPS is enabled but this partition does not support FIPS",
+                                                    "type": "error"
+                                                }
+                                            ],
+                                            "type": "tree"
+                                        },
+                                        {
+                                            "conditions": [],
+                                            "endpoint": {
+                                                "url": "https://qbusiness.{Region}.{PartitionResult#dnsSuffix}",
+                                                "properties": {},
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        }
+                                    ],
+                                    "type": "tree"
+                                }
+                            ],
+                            "type": "tree"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid Configuration: Missing Region",
+                            "type": "error"
+                        }
+                    ]
+                },
+                "smithy.rules#endpointTests": {
+                    "testCases": [
+                        {
+                            "documentation": "For region us-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://qbusiness-fips.us-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://qbusiness.us-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://qbusiness-fips.cn-north-1.api.amazonwebservices.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://qbusiness.cn-north-1.api.amazonwebservices.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://qbusiness-fips.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://qbusiness.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with fips enabled and dualstack disabled",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": true,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "Missing region",
+                            "expect": {
+                                "error": "Invalid Configuration: Missing Region"
+                            }
+                        }
+                    ],
+                    "version": "1.0"
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#ExternalResourceException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.qbusiness#ErrorMessage",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>An external resource that you configured with your application is returning errors and preventing this operation from succeeding. Fix those errors and try again. </p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 424
+            }
+        },
+        "com.amazonaws.qbusiness#FailedAttachmentEvent": {
+            "type": "structure",
+            "members": {
+                "conversationId": {
+                    "target": "com.amazonaws.qbusiness#ConversationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The identifier of the conversation associated with the failed file upload.</p>"
+                    }
+                },
+                "userMessageId": {
+                    "target": "com.amazonaws.qbusiness#MessageId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the end user chat message associated with the file upload.</p>"
+                    }
+                },
+                "systemMessageId": {
+                    "target": "com.amazonaws.qbusiness#MessageId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the AI-generated message associated with the file upload.</p>"
+                    }
+                },
+                "attachment": {
+                    "target": "com.amazonaws.qbusiness#AttachmentOutput"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A failed file upload during web experience chat.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#FailedDocument": {
+            "type": "structure",
+            "members": {
+                "id": {
+                    "target": "com.amazonaws.qbusiness#DocumentId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the document that couldn't be removed from the Amazon Q Business index.</p>"
+                    }
+                },
+                "error": {
+                    "target": "com.amazonaws.qbusiness#ErrorDetail",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An explanation for why the document couldn't be removed from the index.</p>"
+                    }
+                },
+                "dataSourceId": {
+                    "target": "com.amazonaws.qbusiness#DataSourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business data source connector that contains the failed document.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A list of documents that could not be removed from an Amazon Q Business index. Each entry contains an error message that indicates why the document couldn't be removed from the index.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#FailedDocuments": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#FailedDocument"
+            }
+        },
+        "com.amazonaws.qbusiness#FaviconUrl": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 1284
+                },
+                "smithy.api#pattern": "^(https?://[a-zA-Z0-9-_.+%/]+\\.(svg|ico))?$"
+            }
+        },
+        "com.amazonaws.qbusiness#FontUrl": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 1284
+                },
+                "smithy.api#pattern": "^(https?://[a-zA-Z0-9-_.+%/]+\\.(ttf|woff|woff2|otf))?$"
+            }
+        },
+        "com.amazonaws.qbusiness#GetApplication": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#GetApplicationRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#GetApplicationResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#requiredActions": [
+                    "qbusiness:ListTagsForResource"
+                ],
+                "smithy.api#documentation": "<p>Gets information about an existing Amazon Q Business application.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}",
+                    "method": "GET"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetApplicationRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetApplicationResponse": {
+            "type": "structure",
+            "members": {
+                "displayName": {
+                    "target": "com.amazonaws.qbusiness#ApplicationName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Amazon Q Business application.</p>"
+                    }
+                },
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application.</p>"
+                    }
+                },
+                "applicationArn": {
+                    "target": "com.amazonaws.qbusiness#ApplicationArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon Q Business application.</p>"
+                    }
+                },
+                "identityType": {
+                    "target": "com.amazonaws.qbusiness#IdentityType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The authentication type being used by a Amazon Q Business application.</p>"
+                    }
+                },
+                "iamIdentityProviderArn": {
+                    "target": "com.amazonaws.qbusiness#IAMIdentityProviderArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of an identity provider being used by an Amazon Q Business application.</p>"
+                    }
+                },
+                "identityCenterApplicationArn": {
+                    "target": "com.amazonaws.qbusiness#IdcApplicationArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the AWS IAM Identity Center instance attached to your Amazon Q Business application.</p>"
+                    }
+                },
+                "roleArn": {
+                    "target": "com.amazonaws.qbusiness#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM with permissions to access your CloudWatch logs and metrics.</p>"
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.qbusiness#ApplicationStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status of the Amazon Q Business application.</p>"
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.qbusiness#Description",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A description for the Amazon Q Business application.</p>"
+                    }
+                },
+                "encryptionConfiguration": {
+                    "target": "com.amazonaws.qbusiness#EncryptionConfiguration",
+                    "traits": {
+                        "aws.cloudformation#cfnMutability": "create-and-read",
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Web Services KMS key that is used to encrypt your data. Amazon Q Business doesn't support asymmetric keys.</p>"
+                    }
+                },
+                "createdAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Unix timestamp when the Amazon Q Business application was last updated.</p>"
+                    }
+                },
+                "updatedAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Unix timestamp when the Amazon Q Business application was last updated.</p>"
+                    }
+                },
+                "error": {
+                    "target": "com.amazonaws.qbusiness#ErrorDetail",
+                    "traits": {
+                        "aws.cloudformation#cfnExcludeProperty": {},
+                        "smithy.api#documentation": "<p>If the <code>Status</code> field is set to <code>ERROR</code>, the <code>ErrorMessage</code> field contains a description of the error that caused the synchronization to fail.</p>"
+                    }
+                },
+                "attachmentsConfiguration": {
+                    "target": "com.amazonaws.qbusiness#AppliedAttachmentsConfiguration",
+                    "traits": {
+                        "aws.cloudformation#cfnExcludeProperty": {},
+                        "smithy.api#documentation": "<p>Settings for whether end users can upload files directly during chat.</p>"
+                    }
+                },
+                "qAppsConfiguration": {
+                    "target": "com.amazonaws.qbusiness#QAppsConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Settings for whether end users can create and use Amazon Q Apps in the web experience.</p>"
+                    }
+                },
+                "personalizationConfiguration": {
+                    "target": "com.amazonaws.qbusiness#PersonalizationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configuration information about chat response personalization. For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/personalizing-chat-responses.html\">Personalizing chat responses</a>.</p>"
+                    }
+                },
+                "autoSubscriptionConfiguration": {
+                    "target": "com.amazonaws.qbusiness#AutoSubscriptionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Settings for auto-subscription behavior for this application. This is only applicable to SAML and OIDC applications.</p>"
+                    }
+                },
+                "clientIdsForOIDC": {
+                    "target": "com.amazonaws.qbusiness#ClientIdsForOIDC",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The OIDC client ID for a Amazon Q Business application.</p>"
+                    }
+                },
+                "quickSightConfiguration": {
+                    "target": "com.amazonaws.qbusiness#QuickSightConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Quick Suite authentication configuration for the Amazon Q Business application.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetChatControlsConfiguration": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#GetChatControlsConfigurationRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#GetChatControlsConfigurationResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets information about chat controls configured for an existing Amazon Q Business application.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/chatcontrols",
+                    "method": "GET",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "topicConfigurations"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetChatControlsConfigurationRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the application for which the chat controls are configured.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "maxResults": {
+                    "target": "com.amazonaws.qbusiness#MaxResultsIntegerForGetTopicConfigurations",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of configured chat controls to return.</p>",
+                        "smithy.api#httpQuery": "maxResults"
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the <code>maxResults</code> response was incomplete because there is more data to retrieve, Amazon Q Business returns a pagination token in the response. You can use this pagination token to retrieve the next set of Amazon Q Business chat controls configured.</p>",
+                        "smithy.api#httpQuery": "nextToken"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetChatControlsConfigurationResponse": {
+            "type": "structure",
+            "members": {
+                "responseScope": {
+                    "target": "com.amazonaws.qbusiness#ResponseScope",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The response scope configured for a Amazon Q Business application. This determines whether your application uses its retrieval augmented generation (RAG) system to generate answers only from your enterprise data, or also uses the large language models (LLM) knowledge to respons to end user questions in chat.</p>"
+                    }
+                },
+                "orchestrationConfiguration": {
+                    "target": "com.amazonaws.qbusiness#AppliedOrchestrationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The chat response orchestration settings for your application.</p> <note> <p>Chat orchestration is optimized to work for English language content. For more details on language support in Amazon Q Business, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/supported-languages.html\">Supported languages</a>.</p> </note>"
+                    }
+                },
+                "blockedPhrases": {
+                    "target": "com.amazonaws.qbusiness#BlockedPhrasesConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The phrases blocked from chat by your chat control configuration.</p>"
+                    }
+                },
+                "topicConfigurations": {
+                    "target": "com.amazonaws.qbusiness#TopicConfigurations",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The topic specific controls configured for a Amazon Q Business application.</p>"
+                    }
+                },
+                "creatorModeConfiguration": {
+                    "target": "com.amazonaws.qbusiness#AppliedCreatorModeConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configuration details for <code>CREATOR_MODE</code>.</p>"
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the <code>maxResults</code> response was incomplete because there is more data to retrieve, Amazon Q Business returns a pagination token in the response. You can use this pagination token to retrieve the next set of Amazon Q Business chat controls configured.</p>"
+                    }
+                },
+                "hallucinationReductionConfiguration": {
+                    "target": "com.amazonaws.qbusiness#HallucinationReductionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The hallucination reduction settings for your application.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetChatResponseConfiguration": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#GetChatResponseConfigurationRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#GetChatResponseConfigurationResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#iamAction": {
+                    "requiredActions": [
+                        "qbusiness:ListTagsForResource"
+                    ]
+                },
+                "smithy.api#documentation": "<p>Retrieves detailed information about a specific chat response configuration from an Amazon Q Business application. This operation returns the complete configuration settings and metadata.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/applications/{applicationId}/chatresponseconfigurations/{chatResponseConfigurationId}"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetChatResponseConfigurationRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the Amazon Q Business application containing the chat response configuration to retrieve.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "chatResponseConfigurationId": {
+                    "target": "com.amazonaws.qbusiness#ChatResponseConfigurationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the chat response configuration to retrieve from the specified application.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetChatResponseConfigurationResponse": {
+            "type": "structure",
+            "members": {
+                "chatResponseConfigurationId": {
+                    "target": "com.amazonaws.qbusiness#ChatResponseConfigurationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the retrieved chat response configuration.</p>"
+                    }
+                },
+                "chatResponseConfigurationArn": {
+                    "target": "com.amazonaws.qbusiness#ChatResponseConfigurationArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the retrieved chat response configuration, which uniquely identifies the resource across all Amazon Web Services services. </p>"
+                    }
+                },
+                "displayName": {
+                    "target": "com.amazonaws.qbusiness#DisplayName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The human-readable name of the retrieved chat response configuration, making it easier to identify among multiple configurations.</p>"
+                    }
+                },
+                "createdAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp indicating when the chat response configuration was initially created.</p>"
+                    }
+                },
+                "inUseConfiguration": {
+                    "target": "com.amazonaws.qbusiness#ChatResponseConfigurationDetail",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The currently active configuration settings that are being used to generate responses in the Amazon Q Business application.</p>"
+                    }
+                },
+                "lastUpdateConfiguration": {
+                    "target": "com.amazonaws.qbusiness#ChatResponseConfigurationDetail",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the most recent update to the configuration, including timestamp and modification details.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetDataAccessor": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#GetDataAccessorRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#GetDataAccessorResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#requiredActions": [
+                    "qbusiness:ListTagsForResource"
+                ],
+                "smithy.api#documentation": "<p>Retrieves information about a specified data accessor. This operation returns details about the data accessor, including its display name, unique identifier, Amazon Resource Name (ARN), the associated Amazon Q Business application and IAM Identity Center application, the IAM role for the ISV, the action configurations, and the timestamps for when the data accessor was created and last updated.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/dataaccessors/{dataAccessorId}",
+                    "method": "GET"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetDataAccessorRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the Amazon Q Business application.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "dataAccessorId": {
+                    "target": "com.amazonaws.qbusiness#DataAccessorId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the data accessor to retrieve.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetDataAccessorResponse": {
+            "type": "structure",
+            "members": {
+                "displayName": {
+                    "target": "com.amazonaws.qbusiness#DataAccessorName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The friendly name of the data accessor.</p>"
+                    }
+                },
+                "dataAccessorId": {
+                    "target": "com.amazonaws.qbusiness#DataAccessorId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the data accessor.</p>"
+                    }
+                },
+                "dataAccessorArn": {
+                    "target": "com.amazonaws.qbusiness#DataAccessorArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the data accessor.</p>"
+                    }
+                },
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the Amazon Q Business application associated with this data accessor.</p>"
+                    }
+                },
+                "idcApplicationArn": {
+                    "target": "com.amazonaws.qbusiness#IdcApplicationArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM Identity Center application associated with this data accessor.</p>"
+                    }
+                },
+                "principal": {
+                    "target": "com.amazonaws.qbusiness#PrincipalRoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role for the ISV associated with this data accessor.</p>"
+                    }
+                },
+                "actionConfigurations": {
+                    "target": "com.amazonaws.qbusiness#ActionConfigurationList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of action configurations specifying the allowed actions and any associated filters.</p>"
+                    }
+                },
+                "authenticationDetail": {
+                    "target": "com.amazonaws.qbusiness#DataAccessorAuthenticationDetail",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The authentication configuration details for the data accessor. This specifies how the ISV authenticates when accessing data through this data accessor.</p>"
+                    }
+                },
+                "createdAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the data accessor was created.</p>"
+                    }
+                },
+                "updatedAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the data accessor was last updated.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetDataSource": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#GetDataSourceRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#GetDataSourceResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#requiredActions": [
+                    "qbusiness:ListTagsForResource"
+                ],
+                "smithy.api#documentation": "<p>Gets information about an existing Amazon Q Business data source connector.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/indices/{indexId}/datasources/{dataSourceId}",
+                    "method": "GET"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetDataSourceRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "indexId": {
+                    "target": "com.amazonaws.qbusiness#IndexId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identfier of the index used with the data source connector.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "dataSourceId": {
+                    "target": "com.amazonaws.qbusiness#DataSourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the data source connector.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetDataSourceResponse": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application.</p>"
+                    }
+                },
+                "indexId": {
+                    "target": "com.amazonaws.qbusiness#IndexId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the index linked to the data source connector.</p>"
+                    }
+                },
+                "dataSourceId": {
+                    "target": "com.amazonaws.qbusiness#DataSourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the data source connector.</p>"
+                    }
+                },
+                "dataSourceArn": {
+                    "target": "com.amazonaws.qbusiness#DataSourceArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the data source.</p>"
+                    }
+                },
+                "displayName": {
+                    "target": "com.amazonaws.qbusiness#DataSourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name for the data source connector.</p>"
+                    }
+                },
+                "type": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the data source connector. For example, <code>S3</code>.</p>"
+                    }
+                },
+                "configuration": {
+                    "target": "com.amazonaws.qbusiness#DataSourceConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The details of how the data source connector is configured.</p>"
+                    }
+                },
+                "vpcConfiguration": {
+                    "target": "com.amazonaws.qbusiness#DataSourceVpcConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configuration information for an Amazon VPC (Virtual Private Cloud) to connect to your data source.</p>"
+                    }
+                },
+                "createdAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Unix timestamp when the data source connector was created.</p>"
+                    }
+                },
+                "updatedAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Unix timestamp when the data source connector was last updated.</p>"
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.qbusiness#Description",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description for the data source connector.</p>"
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.qbusiness#DataSourceStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current status of the data source connector. When the <code>Status</code> field value is <code>FAILED</code>, the <code>ErrorMessage</code> field contains a description of the error that caused the data source connector to fail.</p>"
+                    }
+                },
+                "syncSchedule": {
+                    "target": "com.amazonaws.qbusiness#SyncSchedule",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The schedule for Amazon Q Business to update the index.</p>"
+                    }
+                },
+                "roleArn": {
+                    "target": "com.amazonaws.qbusiness#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the role with permission to access the data source and required resources.</p>"
+                    }
+                },
+                "error": {
+                    "target": "com.amazonaws.qbusiness#ErrorDetail",
+                    "traits": {
+                        "aws.cloudformation#cfnExcludeProperty": {},
+                        "smithy.api#documentation": "<p>When the <code>Status</code> field value is <code>FAILED</code>, the <code>ErrorMessage</code> field contains a description of the error that caused the data source connector to fail.</p>"
+                    }
+                },
+                "documentEnrichmentConfiguration": {
+                    "target": "com.amazonaws.qbusiness#DocumentEnrichmentConfiguration"
+                },
+                "mediaExtractionConfiguration": {
+                    "target": "com.amazonaws.qbusiness#MediaExtractionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configuration for extracting information from media in documents for the data source. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetDocumentContent": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#GetDocumentContentRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#GetDocumentContentResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Retrieves the content of a document that was ingested into Amazon Q Business. This API validates user authorization against document ACLs before returning a pre-signed URL for secure document access. You can download or view source documents referenced in chat responses through the URL.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/index/{indexId}/documents/{documentId}/content",
+                    "method": "GET"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetDocumentContentRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the Amazon Q Business application containing the document. This ensures the request is scoped to the correct application environment and its associated security policies.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "indexId": {
+                    "target": "com.amazonaws.qbusiness#IndexId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the index where documents are indexed.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "dataSourceId": {
+                    "target": "com.amazonaws.qbusiness#DataSourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the data source from which the document was ingested. This field is not present if the document is ingested by directly calling the BatchPutDocument API. If the document is from a file-upload data source, the datasource will be \"uploaded-docs-file-stat-datasourceid\".</p>",
+                        "smithy.api#httpQuery": "dataSourceId"
+                    }
+                },
+                "documentId": {
+                    "target": "com.amazonaws.qbusiness#DocumentId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the document that is indexed via BatchPutDocument API or file-upload or connector sync. It is also found in chat or chatSync response.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "outputFormat": {
+                    "target": "com.amazonaws.qbusiness#OutputFormat",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Document outputFormat. Defaults to RAW if not selected.</p>",
+                        "smithy.api#httpQuery": "outputFormat"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetDocumentContentResponse": {
+            "type": "structure",
+            "members": {
+                "presignedUrl": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A pre-signed URL that provides temporary access to download the document content directly from Amazon Q Business. The URL expires after 5 minutes for security purposes. This URL is generated only after successful ACL validation.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "mimeType": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The MIME type of the document content. When outputFormat is RAW, this corresponds to the original document's MIME type (e.g., application/pdf, text/plain, application/vnd.openxmlformats-officedocument.wordprocessingml.document). When outputFormat is EXTRACTED, the MIME type is always application/json.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetGroup": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#GetGroupRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#GetGroupResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Describes a group by group name.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/applications/{applicationId}/indices/{indexId}/groups/{groupName}"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetGroupRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the application id the group is attached to.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "indexId": {
+                    "target": "com.amazonaws.qbusiness#IndexId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the index the group is attached to.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "groupName": {
+                    "target": "com.amazonaws.qbusiness#GroupName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the group.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "dataSourceId": {
+                    "target": "com.amazonaws.qbusiness#DataSourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the data source the group is attached to.</p>",
+                        "smithy.api#httpQuery": "dataSourceId"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetGroupResponse": {
+            "type": "structure",
+            "members": {
+                "status": {
+                    "target": "com.amazonaws.qbusiness#GroupStatusDetail",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current status of the group.</p>"
+                    }
+                },
+                "statusHistory": {
+                    "target": "com.amazonaws.qbusiness#GroupStatusDetails",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status history of the group.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetIndex": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#GetIndexRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#GetIndexResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#requiredActions": [
+                    "qbusiness:ListTagsForResource"
+                ],
+                "smithy.api#documentation": "<p>Gets information about an existing Amazon Q Business index.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/indices/{indexId}",
+                    "method": "GET"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetIndexRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application connected to the index.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "indexId": {
+                    "target": "com.amazonaws.qbusiness#IndexId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business index you want information on.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetIndexResponse": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application associated with the index.</p>"
+                    }
+                },
+                "indexId": {
+                    "target": "com.amazonaws.qbusiness#IndexId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business index.</p>"
+                    }
+                },
+                "displayName": {
+                    "target": "com.amazonaws.qbusiness#IndexName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Amazon Q Business index.</p>"
+                    }
+                },
+                "indexArn": {
+                    "target": "com.amazonaws.qbusiness#IndexArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The Amazon Resource Name (ARN) of the Amazon Q Business index. </p>"
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.qbusiness#IndexStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current status of the index. When the value is <code>ACTIVE</code>, the index is ready for use. If the <code>Status</code> field value is <code>FAILED</code>, the <code>ErrorMessage</code> field contains a message that explains why.</p>"
+                    }
+                },
+                "type": {
+                    "target": "com.amazonaws.qbusiness#IndexType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of index attached to your Amazon Q Business application.</p>"
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.qbusiness#Description",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description for the Amazon Q Business index.</p>"
+                    }
+                },
+                "createdAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Unix timestamp when the Amazon Q Business index was created.</p>"
+                    }
+                },
+                "updatedAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Unix timestamp when the Amazon Q Business index was last updated.</p>"
+                    }
+                },
+                "capacityConfiguration": {
+                    "target": "com.amazonaws.qbusiness#IndexCapacityConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The storage capacity units chosen for your Amazon Q Business index.</p>"
+                    }
+                },
+                "documentAttributeConfigurations": {
+                    "target": "com.amazonaws.qbusiness#DocumentAttributeConfigurations",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configuration information for document attributes or metadata. Document metadata are fields associated with your documents. For example, the company department name associated with each document. For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/business-use-dg/doc-attributes-types.html#doc-attributes\">Understanding document attributes</a>.</p>"
+                    }
+                },
+                "error": {
+                    "target": "com.amazonaws.qbusiness#ErrorDetail",
+                    "traits": {
+                        "aws.cloudformation#cfnExcludeProperty": {},
+                        "smithy.api#documentation": "<p>When the <code>Status</code> field value is <code>FAILED</code>, the <code>ErrorMessage</code> field contains a message that explains why.</p>"
+                    }
+                },
+                "indexStatistics": {
+                    "target": "com.amazonaws.qbusiness#IndexStatistics",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Provides information about the number of documents indexed.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetMedia": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#GetMediaRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#GetMediaResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#LicenseNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#MediaTooLargeException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Returns the image bytes corresponding to a media object. If you have implemented your own application with the Chat and ChatSync APIs, and have enabled content extraction from visual data in Amazon Q Business, you use the GetMedia API operation to download the images so you can show them in your UI with responses.</p> <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/extracting-meaning-from-images.html\">Extracting semantic meaning from images and visuals</a>.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/applications/{applicationId}/conversations/{conversationId}/messages/{messageId}/media/{mediaId}"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetMediaRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business which contains the media object.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "conversationId": {
+                    "target": "com.amazonaws.qbusiness#ConversationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business conversation.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "messageId": {
+                    "target": "com.amazonaws.qbusiness#MessageId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business message.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "mediaId": {
+                    "target": "com.amazonaws.qbusiness#MediaId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the media object. You can find this in the <code>sourceAttributions</code> returned by the <code>Chat</code>, <code>ChatSync</code>, and <code>ListMessages</code> API responses.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetMediaResponse": {
+            "type": "structure",
+            "members": {
+                "mediaBytes": {
+                    "target": "com.amazonaws.qbusiness#Blob",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The base64-encoded bytes of the media object.</p>"
+                    }
+                },
+                "mediaMimeType": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The MIME type of the media object (image/png).</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetPlugin": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#GetPluginRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#GetPluginResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#requiredActions": [
+                    "qbusiness:ListTagsForResource"
+                ],
+                "smithy.api#documentation": "<p>Gets information about an existing Amazon Q Business plugin.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/applications/{applicationId}/plugins/{pluginId}"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetPluginRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the application which contains the plugin.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "pluginId": {
+                    "target": "com.amazonaws.qbusiness#PluginId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the plugin.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetPluginResponse": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the application which contains the plugin.</p>"
+                    }
+                },
+                "pluginId": {
+                    "target": "com.amazonaws.qbusiness#PluginId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the plugin.</p>"
+                    }
+                },
+                "displayName": {
+                    "target": "com.amazonaws.qbusiness#PluginName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the plugin.</p>"
+                    }
+                },
+                "type": {
+                    "target": "com.amazonaws.qbusiness#PluginType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the plugin.</p>"
+                    }
+                },
+                "serverUrl": {
+                    "target": "com.amazonaws.qbusiness#Url",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The source URL used for plugin configuration.</p>"
+                    }
+                },
+                "authConfiguration": {
+                    "target": "com.amazonaws.qbusiness#PluginAuthConfiguration"
+                },
+                "customPluginConfiguration": {
+                    "target": "com.amazonaws.qbusiness#CustomPluginConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configuration information required to create a custom plugin.</p>"
+                    }
+                },
+                "buildStatus": {
+                    "target": "com.amazonaws.qbusiness#PluginBuildStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current status of a plugin. A plugin is modified asynchronously.</p>"
+                    }
+                },
+                "pluginArn": {
+                    "target": "com.amazonaws.qbusiness#PluginArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the role with permission to access resources needed to create the plugin.</p>"
+                    }
+                },
+                "state": {
+                    "target": "com.amazonaws.qbusiness#PluginState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current state of the plugin.</p>"
+                    }
+                },
+                "createdAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp for when the plugin was created.</p>"
+                    }
+                },
+                "updatedAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp for when the plugin was last updated.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetPolicy": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#GetPolicyRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#GetPolicyResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Retrieves the current permission policy for a Amazon Q Business application. The policy is returned as a JSON-formatted string and defines the IAM actions that are allowed or denied for the application's resources.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/policy",
+                    "method": "GET"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetPolicyRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the Amazon Q Business application.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetPolicyResponse": {
+            "type": "structure",
+            "members": {
+                "policy": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The JSON representation of the permission policy.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetRetriever": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#GetRetrieverRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#GetRetrieverResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#requiredActions": [
+                    "qbusiness:ListTagsForResource"
+                ],
+                "smithy.api#documentation": "<p>Gets information about an existing retriever used by an Amazon Q Business application.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/applications/{applicationId}/retrievers/{retrieverId}"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetRetrieverRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application using the retriever.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "retrieverId": {
+                    "target": "com.amazonaws.qbusiness#RetrieverId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the retriever.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetRetrieverResponse": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application using the retriever. </p>"
+                    }
+                },
+                "retrieverId": {
+                    "target": "com.amazonaws.qbusiness#RetrieverId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the retriever.</p>"
+                    }
+                },
+                "retrieverArn": {
+                    "target": "com.amazonaws.qbusiness#RetrieverArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role associated with the retriever.</p>"
+                    }
+                },
+                "type": {
+                    "target": "com.amazonaws.qbusiness#RetrieverType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the retriever.</p>"
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.qbusiness#RetrieverStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status of the retriever.</p>"
+                    }
+                },
+                "displayName": {
+                    "target": "com.amazonaws.qbusiness#RetrieverName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the retriever.</p>"
+                    }
+                },
+                "configuration": {
+                    "target": "com.amazonaws.qbusiness#RetrieverConfiguration"
+                },
+                "roleArn": {
+                    "target": "com.amazonaws.qbusiness#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the role with the permission to access the retriever and required resources.</p>"
+                    }
+                },
+                "createdAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Unix timestamp when the retriever was created.</p>"
+                    }
+                },
+                "updatedAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Unix timestamp when the retriever was last updated.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetUser": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#GetUserRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#GetUserResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Describes the universally unique identifier (UUID) associated with a local user in a data source.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/applications/{applicationId}/users/{userId}"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetUserRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the application connected to the user.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "userId": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The user email address attached to the user.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetUserResponse": {
+            "type": "structure",
+            "members": {
+                "userAliases": {
+                    "target": "com.amazonaws.qbusiness#UserAliases",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of user aliases attached to a user.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetWebExperience": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#GetWebExperienceRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#GetWebExperienceResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#requiredActions": [
+                    "qbusiness:ListTagsForResource"
+                ],
+                "smithy.api#documentation": "<p>Gets information about an existing Amazon Q Business web experience.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/experiences/{webExperienceId}",
+                    "method": "GET"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetWebExperienceRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application linked to the web experience.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "webExperienceId": {
+                    "target": "com.amazonaws.qbusiness#WebExperienceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business web experience. </p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GetWebExperienceResponse": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application linked to the web experience.</p>"
+                    }
+                },
+                "webExperienceId": {
+                    "target": "com.amazonaws.qbusiness#WebExperienceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business web experience.</p>"
+                    }
+                },
+                "webExperienceArn": {
+                    "target": "com.amazonaws.qbusiness#WebExperienceArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the role with the permission to access the Amazon Q Business web experience and required resources.</p>"
+                    }
+                },
+                "defaultEndpoint": {
+                    "target": "com.amazonaws.qbusiness#Url",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The endpoint of your Amazon Q Business web experience.</p>"
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.qbusiness#WebExperienceStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current status of the Amazon Q Business web experience. When the <code>Status</code> field value is <code>FAILED</code>, the <code>ErrorMessage</code> field contains a description of the error that caused the data source connector to fail. </p>"
+                    }
+                },
+                "createdAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Unix timestamp when the Amazon Q Business web experience was last created.</p>"
+                    }
+                },
+                "updatedAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Unix timestamp when the Amazon Q Business web experience was last updated.</p>"
+                    }
+                },
+                "title": {
+                    "target": "com.amazonaws.qbusiness#WebExperienceTitle",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The title for your Amazon Q Business web experience. </p>"
+                    }
+                },
+                "subtitle": {
+                    "target": "com.amazonaws.qbusiness#WebExperienceSubtitle",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The subtitle for your Amazon Q Business web experience. </p>"
+                    }
+                },
+                "welcomeMessage": {
+                    "target": "com.amazonaws.qbusiness#WebExperienceWelcomeMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The customized welcome message for end users of an Amazon Q Business web experience.</p>"
+                    }
+                },
+                "samplePromptsControlMode": {
+                    "target": "com.amazonaws.qbusiness#WebExperienceSamplePromptsControlMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Determines whether sample prompts are enabled in the web experience for an end user.</p>"
+                    }
+                },
+                "origins": {
+                    "target": "com.amazonaws.qbusiness#WebExperienceOrigins",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Gets the website domain origins that are allowed to embed the Amazon Q Business web experience. The <i>domain origin</i> refers to the base URL for accessing a website including the protocol (<code>http/https</code>), the domain name, and the port number (if specified). </p>"
+                    }
+                },
+                "roleArn": {
+                    "target": "com.amazonaws.qbusiness#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The Amazon Resource Name (ARN) of the service role attached to your web experience.</p>"
+                    }
+                },
+                "identityProviderConfiguration": {
+                    "target": "com.amazonaws.qbusiness#IdentityProviderConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the identity provider (IdP) used to authenticate end users of an Amazon Q Business web experience.</p>"
+                    }
+                },
+                "authenticationConfiguration": {
+                    "target": "com.amazonaws.qbusiness#WebExperienceAuthConfiguration",
+                    "traits": {
+                        "smithy.api#deprecated": {
+                            "message": "Property associated with legacy SAML IdP flow. Deprecated in favor of using AWS IAM Identity Center for user management."
+                        },
+                        "smithy.api#documentation": "<p>The authentication configuration information for your Amazon Q Business web experience.</p>"
+                    }
+                },
+                "error": {
+                    "target": "com.amazonaws.qbusiness#ErrorDetail",
+                    "traits": {
+                        "aws.cloudformation#cfnExcludeProperty": {},
+                        "smithy.api#documentation": "<p>When the <code>Status</code> field value is <code>FAILED</code>, the <code>ErrorMessage</code> field contains a description of the error that caused the data source connector to fail.</p>"
+                    }
+                },
+                "browserExtensionConfiguration": {
+                    "target": "com.amazonaws.qbusiness#BrowserExtensionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The browser extension configuration for an Amazon Q Business web experience.</p>"
+                    }
+                },
+                "customizationConfiguration": {
+                    "target": "com.amazonaws.qbusiness#CustomizationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Gets the custom logo, favicon, font, and color used in the Amazon Q web experience. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#GroupIdentifier": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 47
+                },
+                "smithy.api#pattern": "^([0-9a-f]{10}-|)[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$"
+            }
+        },
+        "com.amazonaws.qbusiness#GroupMembers": {
+            "type": "structure",
+            "members": {
+                "memberGroups": {
+                    "target": "com.amazonaws.qbusiness#MemberGroups",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of sub groups that belong to a group. For example, the sub groups \"Research\", \"Engineering\", and \"Sales and Marketing\" all belong to the group \"Company\".</p>"
+                    }
+                },
+                "memberUsers": {
+                    "target": "com.amazonaws.qbusiness#MemberUsers",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of users that belong to a group. For example, a list of interns all belong to the \"Interns\" group.</p>"
+                    }
+                },
+                "s3PathForGroupMembers": {
+                    "target": "com.amazonaws.qbusiness#S3"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A list of users or sub groups that belong to a group. This is for generating Amazon Q Business chat results only from document a user has access to.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#GroupName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1024
+                },
+                "smithy.api#pattern": "^\\P{C}*$"
+            }
+        },
+        "com.amazonaws.qbusiness#GroupStatus": {
+            "type": "enum",
+            "members": {
+                "FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FAILED"
+                    }
+                },
+                "SUCCEEDED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SUCCEEDED"
+                    }
+                },
+                "PROCESSING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PROCESSING"
+                    }
+                },
+                "DELETING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETING"
+                    }
+                },
+                "DELETED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETED"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#GroupStatusDetail": {
+            "type": "structure",
+            "members": {
+                "status": {
+                    "target": "com.amazonaws.qbusiness#GroupStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status of a group.</p>"
+                    }
+                },
+                "lastUpdatedAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Unix timestamp when the Amazon Q Business application was last updated.</p>"
+                    }
+                },
+                "errorDetail": {
+                    "target": "com.amazonaws.qbusiness#ErrorDetail",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The details of an error associated a group status.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides the details of a group's status.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#GroupStatusDetails": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#GroupStatusDetail"
+            }
+        },
+        "com.amazonaws.qbusiness#GroupSummary": {
+            "type": "structure",
+            "members": {
+                "groupName": {
+                    "target": "com.amazonaws.qbusiness#GroupName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the group the summary information is for.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Summary information for groups.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#GroupSummaryList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#GroupSummary"
+            }
+        },
+        "com.amazonaws.qbusiness#HallucinationReductionConfiguration": {
+            "type": "structure",
+            "members": {
+                "hallucinationReductionControl": {
+                    "target": "com.amazonaws.qbusiness#HallucinationReductionControl",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Controls whether hallucination reduction has been enabled or disabled for your application. The default status is <code>DISABLED</code>. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration information required to setup hallucination reduction. For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/hallucination-reduction.html\"> hallucination reduction</a>.</p> <note> <p>The hallucination reduction feature won't work if chat orchestration controls are enabled for your application.</p> </note>"
+            }
+        },
+        "com.amazonaws.qbusiness#HallucinationReductionControl": {
+            "type": "enum",
+            "members": {
+                "ENABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ENABLED"
+                    }
+                },
+                "DISABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DISABLED"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#HookConfiguration": {
+            "type": "structure",
+            "members": {
+                "invocationCondition": {
+                    "target": "com.amazonaws.qbusiness#DocumentAttributeCondition",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The condition used for when a Lambda function should be invoked.</p> <p>For example, you can specify a condition that if there are empty date-time values, then Amazon Q Business should invoke a function that inserts the current date-time.</p>"
+                    }
+                },
+                "lambdaArn": {
+                    "target": "com.amazonaws.qbusiness#LambdaArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Lambda function during ingestion. For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/cde-lambda-operations.html\">Using Lambda functions for Amazon Q Business document enrichment</a>.</p>"
+                    }
+                },
+                "s3BucketName": {
+                    "target": "com.amazonaws.qbusiness#S3BucketName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Stores the original, raw documents or the structured, parsed documents before and after altering them. For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/business-use-dg/cde-lambda-operations.html#cde-lambda-operations-data-contracts\">Data contracts for Lambda functions</a>.</p>"
+                    }
+                },
+                "roleArn": {
+                    "target": "com.amazonaws.qbusiness#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of a role with permission to run <code>PreExtractionHookConfiguration</code> and <code>PostExtractionHookConfiguration</code> for altering document metadata and content during the document ingestion process.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides the configuration information for invoking a Lambda function in Lambda to alter document metadata and content when ingesting documents into Amazon Q Business.</p> <p>You can configure your Lambda function using the <code>PreExtractionHookConfiguration</code> parameter if you want to apply advanced alterations on the original or raw documents.</p> <p>If you want to apply advanced alterations on the Amazon Q Business structured documents, you must configure your Lambda function using <code>PostExtractionHookConfiguration</code>.</p> <p>You can only invoke one Lambda function. However, this function can invoke other functions it requires.</p> <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/business-use-dg/custom-document-enrichment.html\">Custom document enrichment</a>. </p>"
+            }
+        },
+        "com.amazonaws.qbusiness#IAMIdentityProviderArn": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 20,
+                    "max": 2048
+                },
+                "smithy.api#pattern": "^arn:[a-z0-9-\\.]{1,63}:iam::\\d{12}:(oidc-provider|saml-provider)/[a-zA-Z0-9_\\.\\/@\\-]+$"
+            }
+        },
+        "com.amazonaws.qbusiness#IdcApplicationArn": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 10,
+                    "max": 1224
+                },
+                "smithy.api#pattern": "^arn:[a-z0-9-\\.]{1,63}:sso::\\d{12}:application/(sso)?ins-[a-zA-Z0-9-.]{16}/apl-[a-zA-Z0-9]{16}$"
+            }
+        },
+        "com.amazonaws.qbusiness#IdcAuthConfiguration": {
+            "type": "structure",
+            "members": {
+                "idcApplicationArn": {
+                    "target": "com.amazonaws.qbusiness#IdcApplicationArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM Identity Center Application used to configure authentication.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "roleArn": {
+                    "target": "com.amazonaws.qbusiness#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role with permissions to perform actions on Amazon Web Services services on your behalf.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about the IAM Identity Center Application used to configure authentication for a plugin.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#IdcTrustedTokenIssuerArn": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 1284
+                },
+                "smithy.api#pattern": "^arn:[a-z0-9-\\.]{1,63}:sso::[0-9]{12}:trustedTokenIssuer/(sso)?ins-[a-zA-Z0-9-.]{16}/tti-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+            }
+        },
+        "com.amazonaws.qbusiness#IdentityProviderConfiguration": {
+            "type": "union",
+            "members": {
+                "samlConfiguration": {
+                    "target": "com.amazonaws.qbusiness#SamlProviderConfiguration"
+                },
+                "openIDConnectConfiguration": {
+                    "target": "com.amazonaws.qbusiness#OpenIDConnectProviderConfiguration"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides information about the identity provider (IdP) used to authenticate end users of an Amazon Q Business web experience.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#IdentityType": {
+            "type": "enum",
+            "members": {
+                "AWS_IAM_IDP_SAML": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AWS_IAM_IDP_SAML"
+                    }
+                },
+                "AWS_IAM_IDP_OIDC": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AWS_IAM_IDP_OIDC"
+                    }
+                },
+                "AWS_IAM_IDC": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AWS_IAM_IDC"
+                    }
+                },
+                "AWS_QUICKSIGHT_IDP": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AWS_QUICKSIGHT_IDP"
+                    }
+                },
+                "ANONYMOUS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ANONYMOUS"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#ImageExtractionConfiguration": {
+            "type": "structure",
+            "members": {
+                "imageExtractionStatus": {
+                    "target": "com.amazonaws.qbusiness#ImageExtractionStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specify whether to extract semantic meaning from images and visuals from documents.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The configuration for extracting semantic meaning from images in documents. For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/extracting-meaning-from-images.html\">Extracting semantic meaning from images and visuals</a>.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#ImageExtractionStatus": {
+            "type": "enum",
+            "members": {
+                "ENABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ENABLED"
+                    }
+                },
+                "DISABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DISABLED"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#ImageSourceDetails": {
+            "type": "structure",
+            "members": {
+                "mediaId": {
+                    "target": "com.amazonaws.qbusiness#MediaId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Unique identifier for the image file.</p>"
+                    }
+                },
+                "mediaMimeType": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The MIME type of the image file.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Details about an image source, including its identifier and format.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#Index": {
+            "type": "structure",
+            "members": {
+                "displayName": {
+                    "target": "com.amazonaws.qbusiness#IndexName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the index.</p>"
+                    }
+                },
+                "indexId": {
+                    "target": "com.amazonaws.qbusiness#IndexId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier for the index.</p>"
+                    }
+                },
+                "createdAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Unix timestamp when the index was created.</p>"
+                    }
+                },
+                "updatedAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Unix timestamp when the index was last updated.</p>"
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.qbusiness#IndexStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current status of the index. When the status is <code>ACTIVE</code>, the index is ready.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Summary information for your Amazon Q Business index.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#IndexArn": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 1284
+                },
+                "smithy.api#pattern": "^arn:[a-z0-9-\\.]{1,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}$"
+            }
+        },
+        "com.amazonaws.qbusiness#IndexCapacityConfiguration": {
+            "type": "structure",
+            "members": {
+                "units": {
+                    "target": "com.amazonaws.qbusiness#IndexCapacityInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of storage units configured for an Amazon Q Business index.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides information about index capacity configuration.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#IndexCapacityInteger": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#IndexId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 36,
+                    "max": 36
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{35}$"
+            }
+        },
+        "com.amazonaws.qbusiness#IndexName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1000
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]*$"
+            }
+        },
+        "com.amazonaws.qbusiness#IndexResource": {
+            "type": "resource",
+            "identifiers": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId"
+                },
+                "indexId": {
+                    "target": "com.amazonaws.qbusiness#IndexId"
+                }
+            },
+            "create": {
+                "target": "com.amazonaws.qbusiness#CreateIndex"
+            },
+            "read": {
+                "target": "com.amazonaws.qbusiness#GetIndex"
+            },
+            "update": {
+                "target": "com.amazonaws.qbusiness#UpdateIndex"
+            },
+            "delete": {
+                "target": "com.amazonaws.qbusiness#DeleteIndex"
+            },
+            "list": {
+                "target": "com.amazonaws.qbusiness#ListIndices"
+            },
+            "resources": [
+                {
+                    "target": "com.amazonaws.qbusiness#DataSourceResource"
+                }
+            ],
+            "traits": {
+                "aws.cloudformation#cfnResource": {
+                    "name": "Index"
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#IndexStatistics": {
+            "type": "structure",
+            "members": {
+                "textDocumentStatistics": {
+                    "target": "com.amazonaws.qbusiness#TextDocumentStatistics",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of documents indexed.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides information about the number of documents in an index.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#IndexStatus": {
+            "type": "enum",
+            "members": {
+                "CREATING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CREATING"
+                    }
+                },
+                "ACTIVE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ACTIVE"
+                    }
+                },
+                "DELETING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETING"
+                    }
+                },
+                "FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FAILED"
+                    }
+                },
+                "UPDATING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "UPDATING"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#IndexType": {
+            "type": "enum",
+            "members": {
+                "ENTERPRISE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ENTERPRISE"
+                    }
+                },
+                "STARTER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "STARTER"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#IndexedTextBytes": {
+            "type": "long",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 0
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#IndexedTextDocument": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 0
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#Indices": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#Index"
+            }
+        },
+        "com.amazonaws.qbusiness#InlineDocumentEnrichmentConfiguration": {
+            "type": "structure",
+            "members": {
+                "condition": {
+                    "target": "com.amazonaws.qbusiness#DocumentAttributeCondition"
+                },
+                "target": {
+                    "target": "com.amazonaws.qbusiness#DocumentAttributeTarget"
+                },
+                "documentContentOperator": {
+                    "target": "com.amazonaws.qbusiness#DocumentContentOperator",
+                    "traits": {
+                        "smithy.api#documentation": "<p> <code>TRUE</code> to delete content if the condition used for the target attribute is met.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides the configuration information for applying basic logic to alter document metadata and content when ingesting documents into Amazon Q Business.</p> <p>To apply advanced logic, to go beyond what you can do with basic logic, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/api-reference/API_HookConfiguration.html\"> <code>HookConfiguration</code> </a>.</p> <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/business-use-dg/custom-document-enrichment.html\">Custom document enrichment</a>. </p>"
+            }
+        },
+        "com.amazonaws.qbusiness#InlineDocumentEnrichmentConfigurations": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#InlineDocumentEnrichmentConfiguration"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 100
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#InstanceArn": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 10,
+                    "max": 1224
+                },
+                "smithy.api#pattern": "^arn:[a-z0-9-\\.]{1,63}:sso:::instance/(sso)?ins-[a-zA-Z0-9-.]{16}$"
+            }
+        },
+        "com.amazonaws.qbusiness#Instruction": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 5,
+                    "max": 1000
+                },
+                "smithy.api#pattern": "^[\\s\\S]*$"
+            }
+        },
+        "com.amazonaws.qbusiness#InstructionCollection": {
+            "type": "structure",
+            "members": {
+                "responseLength": {
+                    "target": "com.amazonaws.qbusiness#Instruction",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the desired length of responses generated by Amazon Q Business. This parameter allows administrators to control whether responses are concise and brief or more detailed and comprehensive.</p>"
+                    }
+                },
+                "targetAudience": {
+                    "target": "com.amazonaws.qbusiness#Instruction",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Defines the intended audience for the responses, allowing Amazon Q Business to tailor its language, terminology, and explanations appropriately. This could range from technical experts to general users with varying levels of domain knowledge.</p>"
+                    }
+                },
+                "perspective": {
+                    "target": "com.amazonaws.qbusiness#Instruction",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Determines the point of view or perspective from which Amazon Q Business generates responses, such as first-person, second-person, or third-person perspective, affecting how information is presented to users.</p>"
+                    }
+                },
+                "outputStyle": {
+                    "target": "com.amazonaws.qbusiness#Instruction",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the formatting and structural style of responses, such as bullet points, paragraphs, step-by-step instructions, or other organizational formats that enhance readability and comprehension.</p>"
+                    }
+                },
+                "identity": {
+                    "target": "com.amazonaws.qbusiness#Instruction",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Defines the persona or identity that Amazon Q Business should adopt when responding to users, allowing for customization of the assistant's character, role, or representation within an organization.</p>"
+                    }
+                },
+                "tone": {
+                    "target": "com.amazonaws.qbusiness#Instruction",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Controls the emotional tone and communication style of responses, such as formal, casual, technical, friendly, or professional, to align with organizational communication standards and user expectations.</p>"
+                    }
+                },
+                "customInstructions": {
+                    "target": "com.amazonaws.qbusiness#Instruction",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Allows administrators to provide specific, custom instructions that guide how Amazon Q Business should respond in particular scenarios or to certain types of queries, enabling fine-grained control over response generation.</p>"
+                    }
+                },
+                "examples": {
+                    "target": "com.amazonaws.qbusiness#Instruction",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Provides sample responses or templates that Amazon Q Business can reference when generating responses, helping to establish consistent patterns and formats for different types of user queries.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A set of instructions that define how Amazon Q Business should generate and format responses to user queries. This collection includes parameters for controlling response characteristics such as length, audience targeting, perspective, style, identity, tone, and custom instructions.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#Integer": {
+            "type": "integer"
+        },
+        "com.amazonaws.qbusiness#IntegrationId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 36,
+                    "max": 36
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]*$"
+            }
+        },
+        "com.amazonaws.qbusiness#IntegrationResource": {
+            "type": "resource",
+            "identifiers": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId"
+                },
+                "integrationId": {
+                    "target": "com.amazonaws.qbusiness#IntegrationId"
+                }
+            },
+            "traits": {
+                "aws.cloudformation#cfnResource": {
+                    "name": "Integration"
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#InternalServerException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.qbusiness#ErrorMessage",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>An issue occurred with the internal server used for your Amazon Q Business service. Wait some minutes and try again, or contact <a href=\"http://aws.amazon.com/contact-us/\">Support</a> for help.</p>",
+                "smithy.api#error": "server",
+                "smithy.api#httpError": 500
+            }
+        },
+        "com.amazonaws.qbusiness#KendraIndexConfiguration": {
+            "type": "structure",
+            "members": {
+                "indexId": {
+                    "target": "com.amazonaws.qbusiness#KendraIndexId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Kendra index.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Stores an Amazon Kendra index as a retriever.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#KendraIndexId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 36,
+                    "max": 36
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{35}$"
+            }
+        },
+        "com.amazonaws.qbusiness#KmsKeyId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 2048
+                },
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.qbusiness#LambdaArn": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 2048
+                },
+                "smithy.api#pattern": "^arn:[a-z0-9-\\.]{1,63}:lambda:[a-z-]*-[0-9]:[0-9]{12}:function:[a-zA-Z0-9-_]+(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})?(:[a-zA-Z0-9-_]+)?$"
+            }
+        },
+        "com.amazonaws.qbusiness#LicenseNotFoundException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.qbusiness#ErrorMessage",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>You don't have permissions to perform the action because your license is inactive. Ask your admin to activate your license and try again after your licence is active.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.qbusiness#ListApplications": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#ListApplicationsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#ListApplicationsResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists Amazon Q Business applications.</p> <note> <p>Amazon Q Business applications may securely transmit data for processing across Amazon Web Services Regions within your geography. For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/cross-region-inference.html\">Cross region inference in Amazon Q Business</a>.</p> </note>",
+                "smithy.api#http": {
+                    "uri": "/applications",
+                    "method": "GET"
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "applications"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListApplicationsRequest": {
+            "type": "structure",
+            "members": {
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the <code>maxResults</code> response was incomplete because there is more data to retrieve, Amazon Q Business returns a pagination token in the response. You can use this pagination token to retrieve the next set of Amazon Q Business applications.</p>",
+                        "smithy.api#httpQuery": "nextToken"
+                    }
+                },
+                "maxResults": {
+                    "target": "com.amazonaws.qbusiness#MaxResultsIntegerForListApplications",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of Amazon Q Business applications to return.</p>",
+                        "smithy.api#httpQuery": "maxResults"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListApplicationsResponse": {
+            "type": "structure",
+            "members": {
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the response is truncated, Amazon Q Business returns this token. You can use this token in a subsequent request to retrieve the next set of applications.</p>"
+                    }
+                },
+                "applications": {
+                    "target": "com.amazonaws.qbusiness#Applications",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An array of summary information on the configuration of one or more Amazon Q Business applications.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListAttachments": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#ListAttachmentsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#ListAttachmentsResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#LicenseNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets a list of attachments associated with an Amazon Q Business web experience or a list of attachements associated with a specific Amazon Q Business conversation.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/attachments",
+                    "method": "GET"
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "attachments"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListAttachmentsRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier for the Amazon Q Business application.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "conversationId": {
+                    "target": "com.amazonaws.qbusiness#ConversationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the Amazon Q Business web experience conversation.</p>",
+                        "smithy.api#httpQuery": "conversationId"
+                    }
+                },
+                "userId": {
+                    "target": "com.amazonaws.qbusiness#UserId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the user involved in the Amazon Q Business web experience conversation.</p>",
+                        "smithy.api#httpQuery": "userId"
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the number of attachments returned exceeds <code>maxResults</code>, Amazon Q Business returns a next token as a pagination token to retrieve the next set of attachments.</p>",
+                        "smithy.api#httpQuery": "nextToken"
+                    }
+                },
+                "maxResults": {
+                    "target": "com.amazonaws.qbusiness#MaxResultsIntegerForListAttachments",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of attachements to return.</p>",
+                        "smithy.api#httpQuery": "maxResults"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListAttachmentsResponse": {
+            "type": "structure",
+            "members": {
+                "attachments": {
+                    "target": "com.amazonaws.qbusiness#AttachmentList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An array of information on one or more attachments.</p>"
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the response is truncated, Amazon Q Business returns this token, which you can use in a later request to list the next set of attachments.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListChatResponseConfigurations": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#ListChatResponseConfigurationsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#ListChatResponseConfigurationsResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Retrieves a list of all chat response configurations available in a specified Amazon Q Business application. This operation returns summary information about each configuration to help administrators manage and select appropriate response settings.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/applications/{applicationId}/chatresponseconfigurations"
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "chatResponseConfigurations"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListChatResponseConfigurationsRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the Amazon Q Business application for which to list available chat response configurations.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "maxResults": {
+                    "target": "com.amazonaws.qbusiness#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of chat response configurations to return in a single response. This parameter helps control pagination of results when many configurations exist.</p>",
+                        "smithy.api#httpQuery": "maxResults"
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A pagination token used to retrieve the next set of results when the number of configurations exceeds the specified <code>maxResults</code> value.</p>",
+                        "smithy.api#httpQuery": "nextToken"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListChatResponseConfigurationsResponse": {
+            "type": "structure",
+            "members": {
+                "chatResponseConfigurations": {
+                    "target": "com.amazonaws.qbusiness#ChatResponseConfigurations",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of chat response configuration summaries, each containing key information about an available configuration in the specified application.</p>"
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A pagination token that can be used in a subsequent request to retrieve additional chat response configurations if the results were truncated due to the <code>maxResults</code> parameter.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListConversations": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#ListConversationsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#ListConversationsResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#LicenseNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists one or more Amazon Q Business conversations.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/conversations",
+                    "method": "GET"
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "conversations"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListConversationsRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "userId": {
+                    "target": "com.amazonaws.qbusiness#UserId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the user involved in the Amazon Q Business web experience conversation. </p>",
+                        "smithy.api#httpQuery": "userId"
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the <code>maxResults</code> response was incomplete because there is more data to retrieve, Amazon Q Business returns a pagination token in the response. You can use this pagination token to retrieve the next set of Amazon Q Business conversations.</p>",
+                        "smithy.api#httpQuery": "nextToken"
+                    }
+                },
+                "maxResults": {
+                    "target": "com.amazonaws.qbusiness#MaxResultsIntegerForListConversations",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of Amazon Q Business conversations to return.</p>",
+                        "smithy.api#httpQuery": "maxResults"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListConversationsResponse": {
+            "type": "structure",
+            "members": {
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the response is truncated, Amazon Q Business returns this token, which you can use in a later request to list the next set of messages.</p>"
+                    }
+                },
+                "conversations": {
+                    "target": "com.amazonaws.qbusiness#Conversations",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An array of summary information on the configuration of one or more Amazon Q Business web experiences.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListDataAccessors": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#ListDataAccessorsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#ListDataAccessorsResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists the data accessors for a Amazon Q Business application. This operation returns a paginated list of data accessor summaries, including the friendly name, unique identifier, ARN, associated IAM role, and creation/update timestamps for each data accessor.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/dataaccessors",
+                    "method": "GET"
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "dataAccessors"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListDataAccessorsRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the Amazon Q Business application.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken1500",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The token for the next set of results. (You received this token from a previous call.)</p>",
+                        "smithy.api#httpQuery": "nextToken"
+                    }
+                },
+                "maxResults": {
+                    "target": "com.amazonaws.qbusiness#MaxResultsIntegerForListDataAccessors",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of results to return in a single call.</p>",
+                        "smithy.api#httpQuery": "maxResults"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListDataAccessorsResponse": {
+            "type": "structure",
+            "members": {
+                "dataAccessors": {
+                    "target": "com.amazonaws.qbusiness#DataAccessors",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of data accessors.</p>"
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken1500",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The token to use to retrieve the next set of results, if there are any.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListDataSourceSyncJobs": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#ListDataSourceSyncJobsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#ListDataSourceSyncJobsResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Get information about an Amazon Q Business data source connector synchronization.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/indices/{indexId}/datasources/{dataSourceId}/syncjobs",
+                    "method": "GET"
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "history"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListDataSourceSyncJobsRequest": {
+            "type": "structure",
+            "members": {
+                "dataSourceId": {
+                    "target": "com.amazonaws.qbusiness#DataSourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The identifier of the data source connector.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application connected to the data source.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "indexId": {
+                    "target": "com.amazonaws.qbusiness#IndexId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the index used with the Amazon Q Business data source connector.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the <code>maxResults</code> response was incpmplete because there is more data to retriever, Amazon Q Business returns a pagination token in the response. You can use this pagination token to retrieve the next set of responses.</p>",
+                        "smithy.api#httpQuery": "nextToken"
+                    }
+                },
+                "maxResults": {
+                    "target": "com.amazonaws.qbusiness#MaxResultsIntegerForListDataSourcesSyncJobs",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of synchronization jobs to return in the response.</p>",
+                        "smithy.api#httpQuery": "maxResults"
+                    }
+                },
+                "startTime": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The start time of the data source connector sync. </p>",
+                        "smithy.api#httpQuery": "startTime"
+                    }
+                },
+                "endTime": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The end time of the data source connector sync.</p>",
+                        "smithy.api#httpQuery": "endTime"
+                    }
+                },
+                "statusFilter": {
+                    "target": "com.amazonaws.qbusiness#DataSourceSyncJobStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Only returns synchronization jobs with the <code>Status</code> field equal to the specified status.</p>",
+                        "smithy.api#httpQuery": "syncStatus"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListDataSourceSyncJobsResponse": {
+            "type": "structure",
+            "members": {
+                "history": {
+                    "target": "com.amazonaws.qbusiness#DataSourceSyncJobs",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A history of synchronization jobs for the data source connector.</p>"
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the response is truncated, Amazon Q Business returns this token. You can use this token in any subsequent request to retrieve the next set of jobs.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListDataSources": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#ListDataSourcesRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#ListDataSourcesResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists the Amazon Q Business data source connectors that you have created.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/indices/{indexId}/datasources",
+                    "method": "GET"
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "dataSources"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListDataSourcesRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application linked to the data source connectors.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "indexId": {
+                    "target": "com.amazonaws.qbusiness#IndexId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the index used with one or more data source connectors.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the <code>maxResults</code> response was incomplete because there is more data to retrieve, Amazon Q Business returns a pagination token in the response. You can use this pagination token to retrieve the next set of Amazon Q Business data source connectors.</p>",
+                        "smithy.api#httpQuery": "nextToken"
+                    }
+                },
+                "maxResults": {
+                    "target": "com.amazonaws.qbusiness#MaxResultsIntegerForListDataSources",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of data source connectors to return.</p>",
+                        "smithy.api#httpQuery": "maxResults"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListDataSourcesResponse": {
+            "type": "structure",
+            "members": {
+                "dataSources": {
+                    "target": "com.amazonaws.qbusiness#DataSources",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An array of summary information for one or more data source connector.</p>"
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the response is truncated, Amazon Q Business returns this token. You can use this token in a subsequent request to retrieve the next set of data source connectors.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListDocuments": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#ListDocumentsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#ListDocumentsResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>A list of documents attached to an index.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/index/{indexId}/documents",
+                    "method": "GET"
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "documentDetailList"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListDocumentsRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the application id the documents are attached to.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "indexId": {
+                    "target": "com.amazonaws.qbusiness#IndexId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the index the documents are attached to.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "dataSourceIds": {
+                    "target": "com.amazonaws.qbusiness#DataSourceIds",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the data sources the documents are attached to.</p>",
+                        "smithy.api#httpQuery": "dataSourceIds"
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the <code>maxResults</code> response was incomplete because there is more data to retrieve, Amazon Q Business returns a pagination token in the response. You can use this pagination token to retrieve the next set of documents.</p>",
+                        "smithy.api#httpQuery": "nextToken"
+                    }
+                },
+                "maxResults": {
+                    "target": "com.amazonaws.qbusiness#MaxResultsIntegerForListDocuments",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of documents to return.</p>",
+                        "smithy.api#httpQuery": "maxResults"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListDocumentsResponse": {
+            "type": "structure",
+            "members": {
+                "documentDetailList": {
+                    "target": "com.amazonaws.qbusiness#DocumentDetailList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of document details.</p>"
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the <code>maxResults</code> response was incomplete because there is more data to retrieve, Amazon Q Business returns a pagination token in the response. You can use this pagination token to retrieve the next set of documents.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListGroups": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#ListGroupsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#ListGroupsResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Provides a list of groups that are mapped to users.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/applications/{applicationId}/indices/{indexId}/groups"
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "items"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListGroupsRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the application for getting a list of groups mapped to users.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "indexId": {
+                    "target": "com.amazonaws.qbusiness#IndexId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the index for getting a list of groups mapped to users.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "updatedEarlierThan": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp identifier used for the latest <code>PUT</code> or <code>DELETE</code> action for mapping users to their groups.</p>",
+                        "smithy.api#httpQuery": "updatedEarlierThan",
+                        "smithy.api#required": {}
+                    }
+                },
+                "dataSourceId": {
+                    "target": "com.amazonaws.qbusiness#DataSourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the data source for getting a list of groups mapped to users.</p>",
+                        "smithy.api#httpQuery": "dataSourceId"
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the previous response was incomplete (because there is more data to retrieve), Amazon Q Business returns a pagination token in the response. You can use this pagination token to retrieve the next set of groups that are mapped to users.</p>",
+                        "smithy.api#httpQuery": "nextToken"
+                    }
+                },
+                "maxResults": {
+                    "target": "com.amazonaws.qbusiness#MaxResultsIntegerForListGroupsRequest",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of returned groups that are mapped to users.</p>",
+                        "smithy.api#httpQuery": "maxResults"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListGroupsResponse": {
+            "type": "structure",
+            "members": {
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the response is truncated, Amazon Q Business returns this token that you can use in the subsequent request to retrieve the next set of groups that are mapped to users.</p>"
+                    }
+                },
+                "items": {
+                    "target": "com.amazonaws.qbusiness#GroupSummaryList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Summary information for list of groups that are mapped to users.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListIndices": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#ListIndicesRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#ListIndicesResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists the Amazon Q Business indices you have created.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/indices",
+                    "method": "GET"
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "indices"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListIndicesRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application connected to the index.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the maxResults response was incomplete because there is more data to retrieve, Amazon Q Business returns a pagination token in the response. You can use this pagination token to retrieve the next set of Amazon Q Business indices.</p>",
+                        "smithy.api#httpQuery": "nextToken"
+                    }
+                },
+                "maxResults": {
+                    "target": "com.amazonaws.qbusiness#MaxResultsIntegerForListIndices",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of indices to return.</p>",
+                        "smithy.api#httpQuery": "maxResults"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListIndicesResponse": {
+            "type": "structure",
+            "members": {
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the response is truncated, Amazon Q Business returns this token that you can use in the subsequent request to retrieve the next set of indexes.</p>"
+                    }
+                },
+                "indices": {
+                    "target": "com.amazonaws.qbusiness#Indices",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An array of information on the items in one or more indexes.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListMessages": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#ListMessagesRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#ListMessagesResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#LicenseNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets a list of messages associated with an Amazon Q Business web experience.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/conversations/{conversationId}",
+                    "method": "GET"
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "messages"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListMessagesRequest": {
+            "type": "structure",
+            "members": {
+                "conversationId": {
+                    "target": "com.amazonaws.qbusiness#ConversationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business web experience conversation.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier for the Amazon Q Business application.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "userId": {
+                    "target": "com.amazonaws.qbusiness#UserId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the user involved in the Amazon Q Business web experience conversation.</p>",
+                        "smithy.api#httpQuery": "userId"
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the number of messages returned exceeds <code>maxResults</code>, Amazon Q Business returns a next token as a pagination token to retrieve the next set of messages.</p>",
+                        "smithy.api#httpQuery": "nextToken"
+                    }
+                },
+                "maxResults": {
+                    "target": "com.amazonaws.qbusiness#MaxResultsIntegerForListMessages",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of messages to return.</p>",
+                        "smithy.api#httpQuery": "maxResults"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListMessagesResponse": {
+            "type": "structure",
+            "members": {
+                "messages": {
+                    "target": "com.amazonaws.qbusiness#Messages",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An array of information on one or more messages.</p>"
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the response is truncated, Amazon Q Business returns this token, which you can use in a later request to list the next set of messages.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListPluginActions": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#ListPluginActionsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#ListPluginActionsResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists configured Amazon Q Business actions for a specific plugin in an Amazon Q Business application.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/applications/{applicationId}/plugins/{pluginId}/actions"
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "items"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListPluginActionsRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application the plugin is attached to.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "pluginId": {
+                    "target": "com.amazonaws.qbusiness#PluginId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business plugin.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the number of plugin actions returned exceeds <code>maxResults</code>, Amazon Q Business returns a next token as a pagination token to retrieve the next set of plugin actions.</p>",
+                        "smithy.api#httpQuery": "nextToken"
+                    }
+                },
+                "maxResults": {
+                    "target": "com.amazonaws.qbusiness#MaxResultsIntegerForListPluginActions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of plugin actions to return.</p>",
+                        "smithy.api#httpQuery": "maxResults"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListPluginActionsResponse": {
+            "type": "structure",
+            "members": {
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the response is truncated, Amazon Q Business returns this token, which you can use in a later request to list the next set of plugin actions.</p>"
+                    }
+                },
+                "items": {
+                    "target": "com.amazonaws.qbusiness#Actions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An array of information on one or more plugin actions.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListPluginTypeActions": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#ListPluginTypeActionsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#ListPluginTypeActionsResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists configured Amazon Q Business actions for any plugin type—both built-in and custom.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/pluginTypes/{pluginType}/actions"
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "items"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListPluginTypeActionsRequest": {
+            "type": "structure",
+            "members": {
+                "pluginType": {
+                    "target": "com.amazonaws.qbusiness#PluginType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the plugin.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the number of plugins returned exceeds <code>maxResults</code>, Amazon Q Business returns a next token as a pagination token to retrieve the next set of plugins.</p>",
+                        "smithy.api#httpQuery": "nextToken"
+                    }
+                },
+                "maxResults": {
+                    "target": "com.amazonaws.qbusiness#MaxResultsIntegerForListPluginTypeActions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of plugins to return.</p>",
+                        "smithy.api#httpQuery": "maxResults"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListPluginTypeActionsResponse": {
+            "type": "structure",
+            "members": {
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the response is truncated, Amazon Q Business returns this token, which you can use in a later request to list the next set of plugins.</p>"
+                    }
+                },
+                "items": {
+                    "target": "com.amazonaws.qbusiness#Actions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An array of information on one or more plugins.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListPluginTypeMetadata": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#ListPluginTypeMetadataRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#ListPluginTypeMetadataResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists metadata for all Amazon Q Business plugin types.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/pluginTypeMetadata"
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "items"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListPluginTypeMetadataRequest": {
+            "type": "structure",
+            "members": {
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the metadata returned exceeds <code>maxResults</code>, Amazon Q Business returns a next token as a pagination token to retrieve the next set of metadata.</p>",
+                        "smithy.api#httpQuery": "nextToken"
+                    }
+                },
+                "maxResults": {
+                    "target": "com.amazonaws.qbusiness#MaxResultsIntegerForListPluginTypeMetadata",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of plugin metadata items to return.</p>",
+                        "smithy.api#httpQuery": "maxResults"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListPluginTypeMetadataResponse": {
+            "type": "structure",
+            "members": {
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the response is truncated, Amazon Q Business returns this token, which you can use in a later request to list the next set of plugin metadata.</p>"
+                    }
+                },
+                "items": {
+                    "target": "com.amazonaws.qbusiness#ListPluginTypeMetadataSummaries",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An array of information on plugin metadata.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListPluginTypeMetadataSummaries": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#PluginTypeMetadataSummary"
+            }
+        },
+        "com.amazonaws.qbusiness#ListPlugins": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#ListPluginsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#ListPluginsResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists configured Amazon Q Business plugins.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/applications/{applicationId}/plugins"
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "plugins"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListPluginsRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the application the plugin is attached to.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the <code>maxResults</code> response was incomplete because there is more data to retrieve, Amazon Q Business returns a pagination token in the response. You can use this pagination token to retrieve the next set of plugins.</p>",
+                        "smithy.api#httpQuery": "nextToken"
+                    }
+                },
+                "maxResults": {
+                    "target": "com.amazonaws.qbusiness#MaxResultsIntegerForListPlugins",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of documents to return.</p>",
+                        "smithy.api#httpQuery": "maxResults"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListPluginsResponse": {
+            "type": "structure",
+            "members": {
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the <code>maxResults</code> response was incomplete because there is more data to retrieve, Amazon Q Business returns a pagination token in the response. You can use this pagination token to retrieve the next set of plugins.</p>"
+                    }
+                },
+                "plugins": {
+                    "target": "com.amazonaws.qbusiness#Plugins",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about a configured plugin.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListRetrievers": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#ListRetrieversRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#ListRetrieversResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists the retriever used by an Amazon Q Business application.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/retrievers",
+                    "method": "GET"
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "retrievers"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListRetrieversRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application using the retriever.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the number of retrievers returned exceeds <code>maxResults</code>, Amazon Q Business returns a next token as a pagination token to retrieve the next set of retrievers.</p>",
+                        "smithy.api#httpQuery": "nextToken"
+                    }
+                },
+                "maxResults": {
+                    "target": "com.amazonaws.qbusiness#MaxResultsIntegerForListRetrieversRequest",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of retrievers returned.</p>",
+                        "smithy.api#httpQuery": "maxResults"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListRetrieversResponse": {
+            "type": "structure",
+            "members": {
+                "retrievers": {
+                    "target": "com.amazonaws.qbusiness#Retrievers",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An array of summary information for one or more retrievers.</p>"
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the response is truncated, Amazon Q Business returns this token, which you can use in a later request to list the next set of retrievers.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListSubscriptions": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#ListSubscriptionsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#ListSubscriptionsResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p> Lists all subscriptions created in an Amazon Q Business application. </p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/applications/{applicationId}/subscriptions"
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "subscriptions"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListSubscriptionsRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application linked to the subscription.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the <code>maxResults</code> response was incomplete because there is more data to retrieve, Amazon Q Business returns a pagination token in the response. You can use this pagination token to retrieve the next set of Amazon Q Business subscriptions.</p>",
+                        "smithy.api#httpQuery": "nextToken"
+                    }
+                },
+                "maxResults": {
+                    "target": "com.amazonaws.qbusiness#MaxResultsIntegerForListSubscriptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of Amazon Q Business subscriptions to return.</p>",
+                        "smithy.api#httpQuery": "maxResults"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListSubscriptionsResponse": {
+            "type": "structure",
+            "members": {
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the response is truncated, Amazon Q Business returns this token. You can use this token in a subsequent request to retrieve the next set of subscriptions.</p>"
+                    }
+                },
+                "subscriptions": {
+                    "target": "com.amazonaws.qbusiness#Subscriptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An array of summary information on the subscriptions configured for an Amazon Q Business application.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListTagsForResource": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#ListTagsForResourceRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#ListTagsForResourceResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets a list of tags associated with a specified resource. Amazon Q Business applications and data sources can have tags associated with them.</p>",
+                "smithy.api#http": {
+                    "uri": "/v1/tags/{resourceARN}",
+                    "method": "GET"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListTagsForResourceRequest": {
+            "type": "structure",
+            "members": {
+                "resourceARN": {
+                    "target": "com.amazonaws.qbusiness#AmazonResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon Q Business application or data source to get a list of tags for.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListTagsForResourceResponse": {
+            "type": "structure",
+            "members": {
+                "tags": {
+                    "target": "com.amazonaws.qbusiness#Tags",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of tags associated with the Amazon Q Business application or data source.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListWebExperiences": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#ListWebExperiencesRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#ListWebExperiencesResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists one or more Amazon Q Business Web Experiences.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/experiences",
+                    "method": "GET"
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "webExperiences"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListWebExperiencesRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application linked to the listed web experiences.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the <code>maxResults</code> response was incomplete because there is more data to retrieve, Amazon Q Business returns a pagination token in the response. You can use this pagination token to retrieve the next set of Amazon Q Business conversations.</p>",
+                        "smithy.api#httpQuery": "nextToken"
+                    }
+                },
+                "maxResults": {
+                    "target": "com.amazonaws.qbusiness#MaxResultsIntegerForListWebExperiencesRequest",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of Amazon Q Business Web Experiences to return.</p>",
+                        "smithy.api#httpQuery": "maxResults"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#ListWebExperiencesResponse": {
+            "type": "structure",
+            "members": {
+                "webExperiences": {
+                    "target": "com.amazonaws.qbusiness#WebExperiences",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An array of summary information for one or more Amazon Q Business experiences.</p>"
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the response is truncated, Amazon Q Business returns this token, which you can use in a later request to list the next set of messages.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#LogoUrl": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 1284
+                },
+                "smithy.api#pattern": "^(https?://[a-zA-Z0-9-_.+%/]+\\.(svg|png))?$"
+            }
+        },
+        "com.amazonaws.qbusiness#Long": {
+            "type": "long"
+        },
+        "com.amazonaws.qbusiness#MaxResults": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 100
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#MaxResultsIntegerForGetTopicConfigurations": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 50
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#MaxResultsIntegerForListApplications": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 100
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#MaxResultsIntegerForListAttachments": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 100
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#MaxResultsIntegerForListConversations": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 100
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#MaxResultsIntegerForListDataAccessors": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 10
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#MaxResultsIntegerForListDataSources": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 10
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#MaxResultsIntegerForListDataSourcesSyncJobs": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 10
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#MaxResultsIntegerForListDocuments": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 100
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#MaxResultsIntegerForListGroupsRequest": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 10
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#MaxResultsIntegerForListIndices": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 100
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#MaxResultsIntegerForListMessages": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 100
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#MaxResultsIntegerForListPluginActions": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 50
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#MaxResultsIntegerForListPluginTypeActions": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 50
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#MaxResultsIntegerForListPluginTypeMetadata": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 50
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#MaxResultsIntegerForListPlugins": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 50
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#MaxResultsIntegerForListRetrieversRequest": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 50
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#MaxResultsIntegerForListSubscriptions": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 100
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#MaxResultsIntegerForListWebExperiencesRequest": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 100
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#MediaExtractionConfiguration": {
+            "type": "structure",
+            "members": {
+                "imageExtractionConfiguration": {
+                    "target": "com.amazonaws.qbusiness#ImageExtractionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configuration for extracting semantic meaning from images in documents. For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/extracting-meaning-from-images.html\">Extracting semantic meaning from images and visuals</a>. </p>"
+                    }
+                },
+                "audioExtractionConfiguration": {
+                    "target": "com.amazonaws.qbusiness#AudioExtractionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configuration settings for extracting and processing audio content from media files.</p>"
+                    }
+                },
+                "videoExtractionConfiguration": {
+                    "target": "com.amazonaws.qbusiness#VideoExtractionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configuration settings for extracting and processing video content from media files.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The configuration for extracting information from media in documents.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#MediaId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 36,
+                    "max": 36
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{35}$"
+            }
+        },
+        "com.amazonaws.qbusiness#MediaTooLargeException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.qbusiness#ErrorMessage",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The requested media object is too large to be returned.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.qbusiness#MemberGroup": {
+            "type": "structure",
+            "members": {
+                "groupName": {
+                    "target": "com.amazonaws.qbusiness#GroupName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the sub group.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "type": {
+                    "target": "com.amazonaws.qbusiness#MembershipType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the sub group.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The sub groups that belong to a group.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#MemberGroups": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#MemberGroup"
+            }
+        },
+        "com.amazonaws.qbusiness#MemberRelation": {
+            "type": "enum",
+            "members": {
+                "AND": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AND"
+                    }
+                },
+                "OR": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "OR"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#MemberUser": {
+            "type": "structure",
+            "members": {
+                "userId": {
+                    "target": "com.amazonaws.qbusiness#DataSourceUserId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the user you want to map to a group.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "type": {
+                    "target": "com.amazonaws.qbusiness#MembershipType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the user.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The users that belong to a group.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#MemberUsers": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#MemberUser"
+            }
+        },
+        "com.amazonaws.qbusiness#MembershipType": {
+            "type": "enum",
+            "members": {
+                "INDEX": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "INDEX"
+                    }
+                },
+                "DATASOURCE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DATASOURCE"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#Message": {
+            "type": "structure",
+            "members": {
+                "messageId": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business web experience message.</p>"
+                    }
+                },
+                "body": {
+                    "target": "com.amazonaws.qbusiness#MessageBody",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The content of the Amazon Q Business web experience message.</p>"
+                    }
+                },
+                "time": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp of the first Amazon Q Business web experience message.</p>"
+                    }
+                },
+                "type": {
+                    "target": "com.amazonaws.qbusiness#MessageType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of Amazon Q Business message, whether <code>HUMAN</code> or <code>AI</code> generated.</p>"
+                    }
+                },
+                "attachments": {
+                    "target": "com.amazonaws.qbusiness#AttachmentsOutput",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A file directly uploaded into an Amazon Q Business web experience chat.</p>"
+                    }
+                },
+                "sourceAttribution": {
+                    "target": "com.amazonaws.qbusiness#SourceAttributions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The source documents used to generate Amazon Q Business web experience message.</p>"
+                    }
+                },
+                "actionReview": {
+                    "target": "com.amazonaws.qbusiness#ActionReview"
+                },
+                "actionExecution": {
+                    "target": "com.amazonaws.qbusiness#ActionExecution"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A message in an Amazon Q Business web experience.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#MessageBody": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 1000
+                },
+                "smithy.api#pattern": "^\\P{C}*$}$"
+            }
+        },
+        "com.amazonaws.qbusiness#MessageId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 36,
+                    "max": 36
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{35}$"
+            }
+        },
+        "com.amazonaws.qbusiness#MessageType": {
+            "type": "enum",
+            "members": {
+                "USER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "USER"
+                    }
+                },
+                "SYSTEM": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SYSTEM"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#MessageUsefulness": {
+            "type": "enum",
+            "members": {
+                "USEFUL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "USEFUL"
+                    }
+                },
+                "NOT_USEFUL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NOT_USEFUL"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#MessageUsefulnessComment": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 1000
+                },
+                "smithy.api#pattern": "^\\P{C}*$"
+            }
+        },
+        "com.amazonaws.qbusiness#MessageUsefulnessFeedback": {
+            "type": "structure",
+            "members": {
+                "usefulness": {
+                    "target": "com.amazonaws.qbusiness#MessageUsefulness",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The usefulness value assigned by an end user to a message.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "reason": {
+                    "target": "com.amazonaws.qbusiness#MessageUsefulnessReason",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The reason for a usefulness rating.</p>"
+                    }
+                },
+                "comment": {
+                    "target": "com.amazonaws.qbusiness#MessageUsefulnessComment",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A comment given by an end user on the usefulness of an AI-generated chat message.</p>"
+                    }
+                },
+                "submittedAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp for when the feedback was submitted.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>End user feedback on an AI-generated web experience chat message usefulness.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#MessageUsefulnessReason": {
+            "type": "enum",
+            "members": {
+                "NOT_FACTUALLY_CORRECT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NOT_FACTUALLY_CORRECT"
+                    }
+                },
+                "HARMFUL_OR_UNSAFE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "HARMFUL_OR_UNSAFE"
+                    }
+                },
+                "INCORRECT_OR_MISSING_SOURCES": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "INCORRECT_OR_MISSING_SOURCES"
+                    }
+                },
+                "NOT_HELPFUL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NOT_HELPFUL"
+                    }
+                },
+                "FACTUALLY_CORRECT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FACTUALLY_CORRECT"
+                    }
+                },
+                "COMPLETE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "COMPLETE"
+                    }
+                },
+                "RELEVANT_SOURCES": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "RELEVANT_SOURCES"
+                    }
+                },
+                "HELPFUL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "HELPFUL"
+                    }
+                },
+                "NOT_BASED_ON_DOCUMENTS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NOT_BASED_ON_DOCUMENTS"
+                    }
+                },
+                "NOT_COMPLETE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NOT_COMPLETE"
+                    }
+                },
+                "NOT_CONCISE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NOT_CONCISE"
+                    }
+                },
+                "OTHER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "OTHER"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#Messages": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#Message"
+            }
+        },
+        "com.amazonaws.qbusiness#MetadataEvent": {
+            "type": "structure",
+            "members": {
+                "conversationId": {
+                    "target": "com.amazonaws.qbusiness#ConversationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the conversation with which the generated metadata is associated.</p>"
+                    }
+                },
+                "userMessageId": {
+                    "target": "com.amazonaws.qbusiness#MessageId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of an Amazon Q Business end user text input message within the conversation.</p>"
+                    }
+                },
+                "systemMessageId": {
+                    "target": "com.amazonaws.qbusiness#MessageId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of an Amazon Q Business AI generated message within the conversation.</p>"
+                    }
+                },
+                "sourceAttributions": {
+                    "target": "com.amazonaws.qbusiness#SourceAttributions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The source documents used to generate the conversation response.</p>"
+                    }
+                },
+                "finalTextMessage": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The final text output message generated by the system.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A metadata event for a AI-generated text output message in a Amazon Q Business conversation, containing associated metadata generated.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#MetricValue": {
+            "type": "string",
+            "traits": {
+                "smithy.api#pattern": "^(([1-9][0-9]*)|0)$"
+            }
+        },
+        "com.amazonaws.qbusiness#NativeIndexConfiguration": {
+            "type": "structure",
+            "members": {
+                "indexId": {
+                    "target": "com.amazonaws.qbusiness#IndexId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier for the Amazon Q Business index.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "version": {
+                    "target": "com.amazonaws.qbusiness#Long",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A read-only field that specifies the version of the <code>NativeIndexConfiguration</code>.</p> <p>Amazon Q Business introduces enhanced document retrieval capabilities in version 2 of <code>NativeIndexConfiguration</code>, focusing on streamlined metadata boosting that prioritizes recency and source relevance to deliver more accurate responses to your queries. Version 2 has the following differences from version 1:</p> <ul> <li> <p>Version 2 supports a single Date field (created_at OR last_updated_at) for recency boosting</p> </li> <li> <p>Version 2 supports a single String field with an ordered list of up to 5 values</p> </li> <li> <p>Version 2 introduces number-based boost levels (ONE, TWO) alongside the text-based levels</p> </li> <li> <p>Version 2 allows specifying prioritization between Date and String fields</p> </li> <li> <p>Version 2 maintains backward compatibility with existing configurations</p> </li> </ul>"
+                    }
+                },
+                "boostingOverride": {
+                    "target": "com.amazonaws.qbusiness#DocumentAttributeBoostingOverrideMap",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Overrides the default boosts applied by Amazon Q Business to supported document attribute data types.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration information for an Amazon Q Business index.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#NextToken": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 800
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#NextToken1500": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1500
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#NoAuthConfiguration": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#documentation": "<p>Information about invoking a custom plugin without any authentication or authorization requirement.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#NumberAttributeBoostingConfiguration": {
+            "type": "structure",
+            "members": {
+                "boostingLevel": {
+                    "target": "com.amazonaws.qbusiness#DocumentAttributeBoostingLevel",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the priority of boosted document attributes in relation to other boosted attributes. This parameter determines how strongly the attribute influences document ranking in search results. <code>NUMBER</code> attributes can serve as additional boosting factors when needed, but are not supported when using <code>NativeIndexConfiguration</code> version 2.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "boostingType": {
+                    "target": "com.amazonaws.qbusiness#NumberAttributeBoostingType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies whether higher or lower numeric values should be prioritized when boosting. Valid values are ASCENDING (higher numbers are more important) and DESCENDING (lower numbers are more important).</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides information on boosting <code>NUMBER</code> type document attributes.</p> <p>In the current boosting implementation, boosting focuses primarily on <code>DATE</code> attributes for recency and <code>STRING</code> attributes for source prioritization. <code>NUMBER</code> attributes can serve as additional boosting factors when needed, but are not supported when using <code>NativeIndexConfiguration</code> version 2.</p> <p>For more information on how boosting document attributes work in Amazon Q Business, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/business-use-dg/metadata-boosting.html\">Boosting using document attributes</a>.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#NumberAttributeBoostingType": {
+            "type": "enum",
+            "members": {
+                "PRIORITIZE_LARGER_VALUES": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PRIORITIZE_LARGER_VALUES"
+                    }
+                },
+                "PRIORITIZE_SMALLER_VALUES": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PRIORITIZE_SMALLER_VALUES"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#OAuth2ClientCredentialConfiguration": {
+            "type": "structure",
+            "members": {
+                "secretArn": {
+                    "target": "com.amazonaws.qbusiness#SecretArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the Secrets Manager secret that stores the OAuth 2.0 credentials/token used for plugin configuration.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "roleArn": {
+                    "target": "com.amazonaws.qbusiness#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of an IAM role used by Amazon Q Business to access the OAuth 2.0 authentication credentials stored in a Secrets Manager secret.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "authorizationUrl": {
+                    "target": "com.amazonaws.qbusiness#Url",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The redirect URL required by the OAuth 2.0 protocol for Amazon Q Business to authenticate a plugin user through a third party authentication server.</p>"
+                    }
+                },
+                "tokenUrl": {
+                    "target": "com.amazonaws.qbusiness#Url",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The URL required by the OAuth 2.0 protocol to exchange an end user authorization code for an access token.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about the OAuth 2.0 authentication credential/token used to configure a plugin.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#OpenIDConnectProviderConfiguration": {
+            "type": "structure",
+            "members": {
+                "secretsArn": {
+                    "target": "com.amazonaws.qbusiness#SecretArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of a Secrets Manager secret containing the OIDC client secret.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "secretsRole": {
+                    "target": "com.amazonaws.qbusiness#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An IAM role with permissions to access KMS to decrypt the Secrets Manager secret containing your OIDC client secret.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about the OIDC-compliant identity provider (IdP) used to authenticate end users of an Amazon Q Business web experience.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#OrchestrationConfiguration": {
+            "type": "structure",
+            "members": {
+                "control": {
+                    "target": "com.amazonaws.qbusiness#OrchestrationControl",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Status information about whether chat orchestration is activated or deactivated for your Amazon Q Business application.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration information required to enable chat orchestration for your Amazon Q Business application.</p> <note> <p>Chat orchestration is optimized to work for English language content. For more details on language support in Amazon Q Business, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/supported-languages.html\">Supported languages</a>.</p> </note>"
+            }
+        },
+        "com.amazonaws.qbusiness#OrchestrationControl": {
+            "type": "enum",
+            "members": {
+                "ENABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ENABLED"
+                    }
+                },
+                "DISABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DISABLED"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#Origin": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 256
+                },
+                "smithy.api#pattern": "^(http://|https://)[a-zA-Z0-9-_.]+(?::[0-9]{1,5})?$"
+            }
+        },
+        "com.amazonaws.qbusiness#OutputFormat": {
+            "type": "enum",
+            "members": {
+                "RAW": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "RAW"
+                    }
+                },
+                "EXTRACTED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "EXTRACTED"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#Payload": {
+            "type": "string",
+            "traits": {
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.qbusiness#PermissionCondition": {
+            "type": "structure",
+            "members": {
+                "conditionOperator": {
+                    "target": "com.amazonaws.qbusiness#PermissionConditionOperator",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The operator to use for the condition evaluation. This determines how the condition values are compared.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "conditionKey": {
+                    "target": "com.amazonaws.qbusiness#PermissionConditionKey",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The key for the condition. This identifies the attribute that the condition applies to.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "conditionValues": {
+                    "target": "com.amazonaws.qbusiness#PermissionConditionValues",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The values to compare against using the specified condition operator.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Defines a condition that restricts when a permission is effective. Conditions allow you to control access based on specific attributes of the request.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#PermissionConditionKey": {
+            "type": "string",
+            "traits": {
+                "smithy.api#pattern": "^aws:[a-zA-Z][a-zA-Z0-9-/:]*$"
+            }
+        },
+        "com.amazonaws.qbusiness#PermissionConditionOperator": {
+            "type": "enum",
+            "members": {
+                "STRING_EQUALS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "StringEquals"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#PermissionConditionValue": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1000
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*$"
+            }
+        },
+        "com.amazonaws.qbusiness#PermissionConditionValues": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#PermissionConditionValue"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#PermissionConditions": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#PermissionCondition"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 10
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#PersonalizationConfiguration": {
+            "type": "structure",
+            "members": {
+                "personalizationControlMode": {
+                    "target": "com.amazonaws.qbusiness#PersonalizationControlMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An option to allow Amazon Q Business to customize chat responses using user specific metadata—specifically, location and job information—in your IAM Identity Center instance.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration information about chat response personalization. For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/personalizing-chat-responses.html\">Personalizing chat responses</a>.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#PersonalizationControlMode": {
+            "type": "enum",
+            "members": {
+                "ENABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ENABLED"
+                    }
+                },
+                "DISABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DISABLED"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#Plugin": {
+            "type": "structure",
+            "members": {
+                "pluginId": {
+                    "target": "com.amazonaws.qbusiness#PluginId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the plugin.</p>"
+                    }
+                },
+                "displayName": {
+                    "target": "com.amazonaws.qbusiness#PluginName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the plugin.</p>"
+                    }
+                },
+                "type": {
+                    "target": "com.amazonaws.qbusiness#PluginType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the plugin.</p>"
+                    }
+                },
+                "serverUrl": {
+                    "target": "com.amazonaws.qbusiness#Url",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The plugin server URL used for configuration.</p>"
+                    }
+                },
+                "state": {
+                    "target": "com.amazonaws.qbusiness#PluginState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current status of the plugin.</p>"
+                    }
+                },
+                "buildStatus": {
+                    "target": "com.amazonaws.qbusiness#PluginBuildStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status of the plugin.</p>"
+                    }
+                },
+                "createdAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp for when the plugin was created.</p>"
+                    }
+                },
+                "updatedAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp for when the plugin was last updated.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about an Amazon Q Business plugin and its configuration.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#PluginArn": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 1284
+                },
+                "smithy.api#pattern": "^arn:[a-z0-9-\\.]{1,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}$"
+            }
+        },
+        "com.amazonaws.qbusiness#PluginAuthConfiguration": {
+            "type": "union",
+            "members": {
+                "basicAuthConfiguration": {
+                    "target": "com.amazonaws.qbusiness#BasicAuthConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the basic authentication credentials used to configure a plugin.</p>"
+                    }
+                },
+                "oAuth2ClientCredentialConfiguration": {
+                    "target": "com.amazonaws.qbusiness#OAuth2ClientCredentialConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the OAuth 2.0 authentication credential/token used to configure a plugin.</p>"
+                    }
+                },
+                "noAuthConfiguration": {
+                    "target": "com.amazonaws.qbusiness#NoAuthConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about invoking a custom plugin without any authentication.</p>"
+                    }
+                },
+                "idcAuthConfiguration": {
+                    "target": "com.amazonaws.qbusiness#IdcAuthConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the IAM Identity Center Application used to configure authentication for a plugin.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Authentication configuration information for an Amazon Q Business plugin.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#PluginBuildStatus": {
+            "type": "enum",
+            "members": {
+                "READY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "READY"
+                    }
+                },
+                "CREATE_IN_PROGRESS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CREATE_IN_PROGRESS"
+                    }
+                },
+                "CREATE_FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CREATE_FAILED"
+                    }
+                },
+                "UPDATE_IN_PROGRESS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "UPDATE_IN_PROGRESS"
+                    }
+                },
+                "UPDATE_FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "UPDATE_FAILED"
+                    }
+                },
+                "DELETE_IN_PROGRESS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETE_IN_PROGRESS"
+                    }
+                },
+                "DELETE_FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETE_FAILED"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#PluginConfiguration": {
+            "type": "structure",
+            "members": {
+                "pluginId": {
+                    "target": "com.amazonaws.qbusiness#PluginId",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The identifier of the plugin you want to use.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration information required to invoke chat in <code>PLUGIN_MODE</code>.</p> <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/guardrails.html\">Admin controls and guardrails</a>, <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/plugins.html\">Plugins</a>, and <a href=\"https://docs.aws.amazon.com/amazonq/latest/business-use-dg/using-web-experience.html#chat-source-scope\">Conversation settings</a>.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#PluginDescription": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 200
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#PluginId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 36,
+                    "max": 36
+                },
+                "smithy.api#pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$"
+            }
+        },
+        "com.amazonaws.qbusiness#PluginName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 100
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]*$"
+            }
+        },
+        "com.amazonaws.qbusiness#PluginResource": {
+            "type": "resource",
+            "identifiers": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId"
+                },
+                "pluginId": {
+                    "target": "com.amazonaws.qbusiness#PluginId"
+                }
+            },
+            "create": {
+                "target": "com.amazonaws.qbusiness#CreatePlugin"
+            },
+            "read": {
+                "target": "com.amazonaws.qbusiness#GetPlugin"
+            },
+            "update": {
+                "target": "com.amazonaws.qbusiness#UpdatePlugin"
+            },
+            "delete": {
+                "target": "com.amazonaws.qbusiness#DeletePlugin"
+            },
+            "list": {
+                "target": "com.amazonaws.qbusiness#ListPlugins"
+            },
+            "traits": {
+                "aws.cloudformation#cfnResource": {
+                    "name": "Plugin"
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#PluginState": {
+            "type": "enum",
+            "members": {
+                "ENABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ENABLED"
+                    }
+                },
+                "DISABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DISABLED"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#PluginType": {
+            "type": "enum",
+            "members": {
+                "SERVICE_NOW": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SERVICE_NOW"
+                    }
+                },
+                "SALESFORCE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SALESFORCE"
+                    }
+                },
+                "JIRA": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "JIRA"
+                    }
+                },
+                "ZENDESK": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ZENDESK"
+                    }
+                },
+                "CUSTOM": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CUSTOM"
+                    }
+                },
+                "QUICKSIGHT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "QUICKSIGHT"
+                    }
+                },
+                "SERVICENOW_NOW_PLATFORM": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SERVICENOW_NOW_PLATFORM"
+                    }
+                },
+                "JIRA_CLOUD": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "JIRA_CLOUD"
+                    }
+                },
+                "SALESFORCE_CRM": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SALESFORCE_CRM"
+                    }
+                },
+                "ZENDESK_SUITE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ZENDESK_SUITE"
+                    }
+                },
+                "ATLASSIAN_CONFLUENCE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ATLASSIAN_CONFLUENCE"
+                    }
+                },
+                "GOOGLE_CALENDAR": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "GOOGLE_CALENDAR"
+                    }
+                },
+                "MICROSOFT_TEAMS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MICROSOFT_TEAMS"
+                    }
+                },
+                "MICROSOFT_EXCHANGE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MICROSOFT_EXCHANGE"
+                    }
+                },
+                "PAGERDUTY_ADVANCE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PAGERDUTY_ADVANCE"
+                    }
+                },
+                "SMARTSHEET": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SMARTSHEET"
+                    }
+                },
+                "ASANA": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ASANA"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#PluginTypeCategory": {
+            "type": "enum",
+            "members": {
+                "CRM": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Customer relationship management (CRM)"
+                    }
+                },
+                "PROJECT_MANAGEMENT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Project management"
+                    }
+                },
+                "COMMUNICATION": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Communication"
+                    }
+                },
+                "PRODUCTIVITY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Productivity"
+                    }
+                },
+                "TICKETING_MANAGEMENT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Ticketing and incident management"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#PluginTypeMetadataSummary": {
+            "type": "structure",
+            "members": {
+                "type": {
+                    "target": "com.amazonaws.qbusiness#PluginType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the plugin.</p>"
+                    }
+                },
+                "category": {
+                    "target": "com.amazonaws.qbusiness#PluginTypeCategory",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The category of the plugin type.</p>"
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description assigned by Amazon Q Business to a plugin. You can't modify this value.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Summary metadata information for a Amazon Q Business plugin.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#Plugins": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#Plugin"
+            }
+        },
+        "com.amazonaws.qbusiness#Principal": {
+            "type": "union",
+            "members": {
+                "user": {
+                    "target": "com.amazonaws.qbusiness#PrincipalUser",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The user associated with the principal.</p>"
+                    }
+                },
+                "group": {
+                    "target": "com.amazonaws.qbusiness#PrincipalGroup",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The group associated with the principal.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides user and group information used for filtering documents to use for generating Amazon Q Business conversation responses.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#PrincipalGroup": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "com.amazonaws.qbusiness#GroupName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the group.</p>"
+                    }
+                },
+                "access": {
+                    "target": "com.amazonaws.qbusiness#ReadAccessType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Provides information about whether to allow or deny access to the principal.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "membershipType": {
+                    "target": "com.amazonaws.qbusiness#MembershipType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of group.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides information about a group associated with the principal.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#PrincipalRoleArn": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1284
+                },
+                "smithy.api#pattern": "^arn:[a-z0-9-\\.]{1,63}:iam::[0-9]{12}:role/[a-zA-Z0-9_/+=,.@-]+$"
+            }
+        },
+        "com.amazonaws.qbusiness#PrincipalUser": {
+            "type": "structure",
+            "members": {
+                "id": {
+                    "target": "com.amazonaws.qbusiness#UserId",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The identifier of the user. </p>"
+                    }
+                },
+                "access": {
+                    "target": "com.amazonaws.qbusiness#ReadAccessType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Provides information about whether to allow or deny access to the principal.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "membershipType": {
+                    "target": "com.amazonaws.qbusiness#MembershipType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of group.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides information about a user associated with a principal.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#Principals": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#Principal"
+            }
+        },
+        "com.amazonaws.qbusiness#PutFeedback": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#PutFeedbackRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Enables your end user to provide feedback on their Amazon Q Business generated chat responses.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/conversations/{conversationId}/messages/{messageId}/feedback",
+                    "method": "POST"
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#PutFeedbackRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the application associated with the feedback.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "userId": {
+                    "target": "com.amazonaws.qbusiness#UserId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the user giving the feedback.</p>",
+                        "smithy.api#httpQuery": "userId"
+                    }
+                },
+                "conversationId": {
+                    "target": "com.amazonaws.qbusiness#ConversationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the conversation the feedback is attached to.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "messageId": {
+                    "target": "com.amazonaws.qbusiness#SystemMessageId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the chat message that the feedback was given for.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "messageCopiedAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp for when the feedback was recorded.</p>"
+                    }
+                },
+                "messageUsefulness": {
+                    "target": "com.amazonaws.qbusiness#MessageUsefulnessFeedback",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The feedback usefulness value given by the user to the chat message.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#PutGroup": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#PutGroupRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#PutGroupResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Create, or updates, a mapping of users—who have access to a document—to groups.</p> <p>You can also map sub groups to groups. For example, the group \"Company Intellectual Property Teams\" includes sub groups \"Research\" and \"Engineering\". These sub groups include their own list of users or people who work in these teams. Only users who work in research and engineering, and therefore belong in the intellectual property group, can see top-secret company documents in their Amazon Q Business chat results.</p> <p>There are two options for creating groups, either passing group members inline or using an S3 file via the S3PathForGroupMembers field. For inline groups, there is a limit of 1000 members per group and for provided S3 files there is a limit of 100 thousand members. When creating a group using an S3 file, you provide both an S3 file and a <code>RoleArn</code> for Amazon Q Buisness to access the file.</p>",
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/applications/{applicationId}/indices/{indexId}/groups"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#PutGroupRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the application in which the user and group mapping belongs.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "indexId": {
+                    "target": "com.amazonaws.qbusiness#IndexId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the index in which you want to map users to their groups.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "groupName": {
+                    "target": "com.amazonaws.qbusiness#GroupName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list that contains your users or sub groups that belong the same group. For example, the group \"Company\" includes the user \"CEO\" and the sub groups \"Research\", \"Engineering\", and \"Sales and Marketing\".</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "dataSourceId": {
+                    "target": "com.amazonaws.qbusiness#DataSourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the data source for which you want to map users to their groups. This is useful if a group is tied to multiple data sources, but you only want the group to access documents of a certain data source. For example, the groups \"Research\", \"Engineering\", and \"Sales and Marketing\" are all tied to the company's documents stored in the data sources Confluence and Salesforce. However, \"Sales and Marketing\" team only needs access to customer-related documents stored in Salesforce.</p>"
+                    }
+                },
+                "type": {
+                    "target": "com.amazonaws.qbusiness#MembershipType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the group.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "groupMembers": {
+                    "target": "com.amazonaws.qbusiness#GroupMembers",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                },
+                "roleArn": {
+                    "target": "com.amazonaws.qbusiness#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of an IAM role that has access to the S3 file that contains your list of users that belong to a group.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#PutGroupResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#QAppsConfiguration": {
+            "type": "structure",
+            "members": {
+                "qAppsControlMode": {
+                    "target": "com.amazonaws.qbusiness#QAppsControlMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Status information about whether end users can create and use Amazon Q Apps in the web experience.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration information about Amazon Q Apps.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#QAppsControlMode": {
+            "type": "enum",
+            "members": {
+                "ENABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ENABLED"
+                    }
+                },
+                "DISABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DISABLED"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#QIamAction": {
+            "type": "string",
+            "traits": {
+                "smithy.api#pattern": "^qbusiness:[a-zA-Z]+$"
+            }
+        },
+        "com.amazonaws.qbusiness#QIamActions": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#QIamAction"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 10
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#QueryText": {
+            "type": "string"
+        },
+        "com.amazonaws.qbusiness#QuickSightConfiguration": {
+            "type": "structure",
+            "members": {
+                "clientNamespace": {
+                    "target": "com.amazonaws.qbusiness#ClientNamespace",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Quick Suite namespace that is used as the identity provider. For more information about Quick Suite namespaces, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/developerguide/namespace-operations.html\">Namespace operations</a>. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The Amazon Quick Suite configuration for an Amazon Q Business application that uses Quick Suite as the identity provider. For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/create-quicksight-integrated-application.html\">Creating an Amazon Quick Suite integrated application</a>.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#ReadAccessType": {
+            "type": "enum",
+            "members": {
+                "ALLOW": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ALLOW"
+                    }
+                },
+                "DENY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DENY"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#RelevantContent": {
+            "type": "structure",
+            "members": {
+                "content": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The actual content of the relevant item.</p>"
+                    }
+                },
+                "documentId": {
+                    "target": "com.amazonaws.qbusiness#DocumentId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the document containing the relevant content.</p>"
+                    }
+                },
+                "documentTitle": {
+                    "target": "com.amazonaws.qbusiness#Title",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The title of the document containing the relevant content.</p>"
+                    }
+                },
+                "documentUri": {
+                    "target": "com.amazonaws.qbusiness#Url",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The URI of the document containing the relevant content.</p>"
+                    }
+                },
+                "documentAttributes": {
+                    "target": "com.amazonaws.qbusiness#DocumentAttributes",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Additional attributes of the document containing the relevant content.</p>"
+                    }
+                },
+                "scoreAttributes": {
+                    "target": "com.amazonaws.qbusiness#ScoreAttributes",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Attributes related to the relevance score of the content.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a piece of content that is relevant to a search query.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#RelevantContentList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#RelevantContent"
+            }
+        },
+        "com.amazonaws.qbusiness#ResourceNotFoundException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.qbusiness#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The message describing a <code>ResourceNotFoundException</code>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "resourceId": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the resource affected.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "resourceType": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the resource affected.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The application or plugin resource you want to use doesn’t exist. Make sure you have provided the correct resource and try again.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 404
+            }
+        },
+        "com.amazonaws.qbusiness#ResponseConfiguration": {
+            "type": "structure",
+            "members": {
+                "instructionCollection": {
+                    "target": "com.amazonaws.qbusiness#InstructionCollection",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A collection of instructions that guide how Amazon Q Business generates responses, including parameters for response length, target audience, perspective, output style, identity, tone, and custom instructions.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration settings to define how Amazon Q Business generates and formats responses to user queries. This includes customization options for response style, tone, length, and other characteristics.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#ResponseConfigurationSummary": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1000
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#ResponseConfigurationType": {
+            "type": "enum",
+            "members": {
+                "ALL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ALL"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#ResponseConfigurations": {
+            "type": "map",
+            "key": {
+                "target": "com.amazonaws.qbusiness#ResponseConfigurationType"
+            },
+            "value": {
+                "target": "com.amazonaws.qbusiness#ResponseConfiguration"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#ResponseScope": {
+            "type": "enum",
+            "members": {
+                "ENTERPRISE_CONTENT_ONLY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ENTERPRISE_CONTENT_ONLY"
+                    }
+                },
+                "EXTENDED_KNOWLEDGE_ENABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "EXTENDED_KNOWLEDGE_ENABLED"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#Retriever": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application using the retriever.</p>"
+                    }
+                },
+                "retrieverId": {
+                    "target": "com.amazonaws.qbusiness#RetrieverId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the retriever used by your Amazon Q Business application.</p>"
+                    }
+                },
+                "type": {
+                    "target": "com.amazonaws.qbusiness#RetrieverType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of your retriever.</p>"
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.qbusiness#RetrieverStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status of your retriever.</p>"
+                    }
+                },
+                "displayName": {
+                    "target": "com.amazonaws.qbusiness#RetrieverName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of your retriever.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Summary information for the retriever used for your Amazon Q Business application.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#RetrieverArn": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 1284
+                },
+                "smithy.api#pattern": "^arn:[a-z0-9-\\.]{1,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}$"
+            }
+        },
+        "com.amazonaws.qbusiness#RetrieverConfiguration": {
+            "type": "union",
+            "members": {
+                "nativeIndexConfiguration": {
+                    "target": "com.amazonaws.qbusiness#NativeIndexConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Provides information on how a Amazon Q Business index used as a retriever for your Amazon Q Business application is configured.</p>"
+                    }
+                },
+                "kendraIndexConfiguration": {
+                    "target": "com.amazonaws.qbusiness#KendraIndexConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Provides information on how the Amazon Kendra index used as a retriever for your Amazon Q Business application is configured.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides information on how the retriever used for your Amazon Q Business application is configured.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#RetrieverContentSource": {
+            "type": "structure",
+            "members": {
+                "retrieverId": {
+                    "target": "com.amazonaws.qbusiness#RetrieverId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the retriever to use as the content source.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Specifies a retriever as the content source for a search.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#RetrieverId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 36,
+                    "max": 36
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{35}$"
+            }
+        },
+        "com.amazonaws.qbusiness#RetrieverName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1000
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]*$"
+            }
+        },
+        "com.amazonaws.qbusiness#RetrieverResource": {
+            "type": "resource",
+            "identifiers": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId"
+                },
+                "retrieverId": {
+                    "target": "com.amazonaws.qbusiness#RetrieverId"
+                }
+            },
+            "create": {
+                "target": "com.amazonaws.qbusiness#CreateRetriever"
+            },
+            "read": {
+                "target": "com.amazonaws.qbusiness#GetRetriever"
+            },
+            "update": {
+                "target": "com.amazonaws.qbusiness#UpdateRetriever"
+            },
+            "delete": {
+                "target": "com.amazonaws.qbusiness#DeleteRetriever"
+            },
+            "list": {
+                "target": "com.amazonaws.qbusiness#ListRetrievers"
+            },
+            "traits": {
+                "aws.cloudformation#cfnResource": {
+                    "name": "Retriever"
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#RetrieverStatus": {
+            "type": "enum",
+            "members": {
+                "CREATING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CREATING"
+                    }
+                },
+                "ACTIVE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ACTIVE"
+                    }
+                },
+                "FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FAILED"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#RetrieverType": {
+            "type": "enum",
+            "members": {
+                "NATIVE_INDEX": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NATIVE_INDEX"
+                    }
+                },
+                "KENDRA_INDEX": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "KENDRA_INDEX"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#Retrievers": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#Retriever"
+            }
+        },
+        "com.amazonaws.qbusiness#RoleArn": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 1284
+                },
+                "smithy.api#pattern": "^arn:[a-z0-9-\\.]{1,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}$"
+            }
+        },
+        "com.amazonaws.qbusiness#Rule": {
+            "type": "structure",
+            "members": {
+                "includedUsersAndGroups": {
+                    "target": "com.amazonaws.qbusiness#UsersAndGroups",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Users and groups to be included in a rule.</p>"
+                    }
+                },
+                "excludedUsersAndGroups": {
+                    "target": "com.amazonaws.qbusiness#UsersAndGroups",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Users and groups to be excluded from a rule.</p>"
+                    }
+                },
+                "ruleType": {
+                    "target": "com.amazonaws.qbusiness#RuleType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of rule.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "ruleConfiguration": {
+                    "target": "com.amazonaws.qbusiness#RuleConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configuration information for a rule.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Guardrail rules for an Amazon Q Business application. Amazon Q Business supports only one rule at a time.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#RuleConfiguration": {
+            "type": "union",
+            "members": {
+                "contentBlockerRule": {
+                    "target": "com.amazonaws.qbusiness#ContentBlockerRule",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A rule for configuring how Amazon Q Business responds when it encounters a a blocked topic.</p>"
+                    }
+                },
+                "contentRetrievalRule": {
+                    "target": "com.amazonaws.qbusiness#ContentRetrievalRule"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides configuration information about a rule.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#RuleType": {
+            "type": "enum",
+            "members": {
+                "CONTENT_BLOCKER_RULE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CONTENT_BLOCKER_RULE"
+                    }
+                },
+                "CONTENT_RETRIEVAL_RULE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CONTENT_RETRIEVAL_RULE"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#Rules": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#Rule"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "max": 10
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#S3": {
+            "type": "structure",
+            "members": {
+                "bucket": {
+                    "target": "com.amazonaws.qbusiness#S3BucketName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the S3 bucket that contains the file.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "key": {
+                    "target": "com.amazonaws.qbusiness#S3ObjectKey",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the file.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information required for Amazon Q Business to find a specific file in an Amazon S3 bucket.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#S3BucketName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 63
+                },
+                "smithy.api#pattern": "^[a-z0-9][\\.\\-a-z0-9]{1,61}[a-z0-9]$"
+            }
+        },
+        "com.amazonaws.qbusiness#S3ObjectKey": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1024
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#SamlAttribute": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 256
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#SamlAuthenticationUrl": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1284
+                },
+                "smithy.api#pattern": "^https://.*$"
+            }
+        },
+        "com.amazonaws.qbusiness#SamlConfiguration": {
+            "type": "structure",
+            "members": {
+                "metadataXML": {
+                    "target": "com.amazonaws.qbusiness#SamlMetadataXML",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The metadata XML that your IdP generated.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "roleArn": {
+                    "target": "com.amazonaws.qbusiness#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of an IAM role assumed by users when they authenticate into their Amazon Q Business web experience, containing the relevant Amazon Q Business permissions for conversing with Amazon Q Business.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "userIdAttribute": {
+                    "target": "com.amazonaws.qbusiness#SamlAttribute",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The user attribute name in your IdP that maps to the user email.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "userGroupAttribute": {
+                    "target": "com.amazonaws.qbusiness#SamlAttribute",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The group attribute name in your IdP that maps to user groups.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides the SAML 2.0 compliant identity provider (IdP) configuration information Amazon Q Business needs to deploy a Amazon Q Business web experience.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#SamlMetadataXML": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1000,
+                    "max": 10000000
+                },
+                "smithy.api#pattern": "^.*$"
+            }
+        },
+        "com.amazonaws.qbusiness#SamlProviderConfiguration": {
+            "type": "structure",
+            "members": {
+                "authenticationUrl": {
+                    "target": "com.amazonaws.qbusiness#SamlAuthenticationUrl",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The URL where Amazon Q Business end users will be redirected for authentication. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about the SAML 2.0-compliant identity provider (IdP) used to authenticate end users of an Amazon Q Business web experience.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#ScoreAttributes": {
+            "type": "structure",
+            "members": {
+                "scoreConfidence": {
+                    "target": "com.amazonaws.qbusiness#ScoreConfidence",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The confidence level of the relevance score.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides information about the relevance score of content.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#ScoreConfidence": {
+            "type": "enum",
+            "members": {
+                "VERY_HIGH": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "VERY_HIGH"
+                    }
+                },
+                "HIGH": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "HIGH"
+                    }
+                },
+                "MEDIUM": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MEDIUM"
+                    }
+                },
+                "LOW": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "LOW"
+                    }
+                },
+                "NOT_AVAILABLE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NOT_AVAILABLE"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#SearchRelevantContent": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#SearchRelevantContentRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#SearchRelevantContentResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#LicenseNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Searches for relevant content in a Amazon Q Business application based on a query. This operation takes a search query text, the Amazon Q Business application identifier, and optional filters (such as content source and maximum results) as input. It returns a list of relevant content items, where each item includes the content text, the unique document identifier, the document title, the document URI, any relevant document attributes, and score attributes indicating the confidence level of the relevance.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/relevant-content",
+                    "method": "POST"
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "relevantContent"
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#SearchRelevantContentRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the Amazon Q Business application to search.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "queryText": {
+                    "target": "com.amazonaws.qbusiness#QueryText",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The text to search for.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "contentSource": {
+                    "target": "com.amazonaws.qbusiness#ContentSource",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The source of content to search in.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "attributeFilter": {
+                    "target": "com.amazonaws.qbusiness#AttributeFilter"
+                },
+                "maxResults": {
+                    "target": "com.amazonaws.qbusiness#MaxResults",
+                    "traits": {
+                        "smithy.api#addedDefault": {},
+                        "smithy.api#default": 10,
+                        "smithy.api#documentation": "<p>The maximum number of results to return.</p>"
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The token for the next set of results. (You received this token from a previous call.)</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#SearchRelevantContentResponse": {
+            "type": "structure",
+            "members": {
+                "relevantContent": {
+                    "target": "com.amazonaws.qbusiness#RelevantContentList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of relevant content items found.</p>"
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.qbusiness#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The token to use to retrieve the next set of results, if there are any.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#SecretArn": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 1284
+                },
+                "smithy.api#pattern": "^arn:[a-z0-9-\\.]{1,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}$"
+            }
+        },
+        "com.amazonaws.qbusiness#SecurityGroupId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 200
+                },
+                "smithy.api#pattern": "^[-0-9a-zA-Z]+$"
+            }
+        },
+        "com.amazonaws.qbusiness#SecurityGroupIds": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#SecurityGroupId"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 10
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#ServiceQuotaExceededException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.qbusiness#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The message describing a <code>ServiceQuotaExceededException</code>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "resourceId": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the resource affected.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "resourceType": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the resource affected.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>You have exceeded the set limits for your Amazon Q Business service. </p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 402
+            }
+        },
+        "com.amazonaws.qbusiness#SessionDurationInMinutes": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 15,
+                    "max": 60
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#SnippetExcerpt": {
+            "type": "structure",
+            "members": {
+                "text": {
+                    "target": "com.amazonaws.qbusiness#SnippetExcerptText",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The relevant text excerpt from a source that was used to generate a citation text segment in an Amazon Q chat response.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains the relevant text excerpt from a source that was used to generate a citation text segment in an Amazon Q Business chat response.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#SnippetExcerptText": {
+            "type": "string"
+        },
+        "com.amazonaws.qbusiness#SourceAttribution": {
+            "type": "structure",
+            "members": {
+                "title": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The title of the document which is the source for the Amazon Q Business generated response. </p>"
+                    }
+                },
+                "snippet": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The content extract from the document on which the generated response is based. </p>"
+                    }
+                },
+                "url": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The URL of the document which is the source for the Amazon Q Business generated response. </p>"
+                    }
+                },
+                "citationNumber": {
+                    "target": "com.amazonaws.qbusiness#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number attached to a citation in an Amazon Q Business generated response.</p>"
+                    }
+                },
+                "updatedAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Unix timestamp when the Amazon Q Business application was last updated.</p>"
+                    }
+                },
+                "textMessageSegments": {
+                    "target": "com.amazonaws.qbusiness#TextSegmentList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A text extract from a source document that is used for source attribution.</p>"
+                    }
+                },
+                "documentId": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the source document used in the citation, obtained from the Amazon Q Business index during chat response generation. This ID is used as input to the <code>GetDocumentContent</code> API to retrieve the actual document content for user verification.</p>"
+                    }
+                },
+                "indexId": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the index containing the source document's metadata and access control information. This links the citation back to the specific Amazon Q Business index where the document's searchable content and permissions are stored.</p>"
+                    }
+                },
+                "datasourceId": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the data source from which the document was ingested. This field is not present if the document is ingested by directly calling the BatchPutDocument API (similar to checkDocumentAccess). If the document is from a file-upload data source, the datasource will be \"uploaded-docs-file-stat-datasourceid\".</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The documents used to generate an Amazon Q Business web experience response.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#SourceAttributionMediaId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 36,
+                    "max": 36
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{35}$"
+            }
+        },
+        "com.amazonaws.qbusiness#SourceAttributions": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#SourceAttribution"
+            },
+            "traits": {
+                "smithy.api#sparse": {}
+            }
+        },
+        "com.amazonaws.qbusiness#SourceDetails": {
+            "type": "union",
+            "members": {
+                "imageSourceDetails": {
+                    "target": "com.amazonaws.qbusiness#ImageSourceDetails",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Details specific to image content within the source.</p>"
+                    }
+                },
+                "audioSourceDetails": {
+                    "target": "com.amazonaws.qbusiness#AudioSourceDetails",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Details specific to audio content within the source.</p>"
+                    }
+                },
+                "videoSourceDetails": {
+                    "target": "com.amazonaws.qbusiness#VideoSourceDetails",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Details specific to video content within the source.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Container for details about different types of media sources (image, audio, or video).</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#StartDataSourceSyncJob": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#StartDataSourceSyncJobRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#StartDataSourceSyncJobResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Starts a data source connector synchronization job. If a synchronization job is already in progress, Amazon Q Business returns a <code>ConflictException</code>.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/indices/{indexId}/datasources/{dataSourceId}/startsync",
+                    "method": "POST"
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#StartDataSourceSyncJobRequest": {
+            "type": "structure",
+            "members": {
+                "dataSourceId": {
+                    "target": "com.amazonaws.qbusiness#DataSourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The identifier of the data source connector. </p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of Amazon Q Business application the data source is connected to.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "indexId": {
+                    "target": "com.amazonaws.qbusiness#IndexId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the index used with the data source connector.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#StartDataSourceSyncJobResponse": {
+            "type": "structure",
+            "members": {
+                "executionId": {
+                    "target": "com.amazonaws.qbusiness#ExecutionId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier for a particular synchronization job.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#StatementId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 100
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9_-]+$"
+            }
+        },
+        "com.amazonaws.qbusiness#Status": {
+            "type": "enum",
+            "members": {
+                "ENABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ENABLED"
+                    }
+                },
+                "DISABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DISABLED"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#StopDataSourceSyncJob": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#StopDataSourceSyncJobRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#StopDataSourceSyncJobResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Stops an Amazon Q Business data source connector synchronization job already in progress.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/indices/{indexId}/datasources/{dataSourceId}/stopsync",
+                    "method": "POST"
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#StopDataSourceSyncJobRequest": {
+            "type": "structure",
+            "members": {
+                "dataSourceId": {
+                    "target": "com.amazonaws.qbusiness#DataSourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The identifier of the data source connector. </p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application that the data source is connected to.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "indexId": {
+                    "target": "com.amazonaws.qbusiness#IndexId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the index used with the Amazon Q Business data source connector.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#StopDataSourceSyncJobResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#String": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 2048
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#StringAttributeBoostingConfiguration": {
+            "type": "structure",
+            "members": {
+                "boostingLevel": {
+                    "target": "com.amazonaws.qbusiness#DocumentAttributeBoostingLevel",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the priority tier ranking of boosting applied to document attributes. For version 2, this parameter indicates the relative ranking between boosted fields (ONE being highest priority, TWO being second highest, etc.) and determines the order in which attributes influence document ranking in search results. For version 1, this parameter specifies the boosting intensity. For version 2, boosting intensity (VERY HIGH, HIGH, MEDIUM, LOW, NONE) are not supported. Note that in version 2, you are not allowed to boost on only one field and make this value TWO.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "attributeValueBoosting": {
+                    "target": "com.amazonaws.qbusiness#StringAttributeValueBoosting",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies specific values of a <code>STRING</code> type document attribute being boosted. When using <code>NativeIndexConfiguration</code> version 2, you can specify up to five values in order of priority.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides information on boosting <code>STRING</code> type document attributes.</p> <note> <p>For <code>STRING</code> and <code>STRING_LIST</code> type document attributes to be used for boosting on the console and the API, they must be enabled for search using the <a href=\"https://docs.aws.amazon.com/amazonq/latest/api-reference/API_DocumentAttributeConfiguration.html\">DocumentAttributeConfiguration</a> object of the <a href=\"https://docs.aws.amazon.com/amazonq/latest/api-reference/API_UpdateIndex.html\">UpdateIndex</a> API. If you haven't enabled searching on these attributes, you can't boost attributes of these data types on either the console or the API.</p> </note> <p>For more information on how boosting document attributes work in Amazon Q Business, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/business-use-dg/metadata-boosting.html\">Boosting using document attributes</a>.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#StringAttributeValueBoosting": {
+            "type": "map",
+            "key": {
+                "target": "com.amazonaws.qbusiness#String"
+            },
+            "value": {
+                "target": "com.amazonaws.qbusiness#StringAttributeValueBoostingLevel"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 10
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#StringAttributeValueBoostingLevel": {
+            "type": "enum",
+            "members": {
+                "LOW": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "LOW"
+                    }
+                },
+                "MEDIUM": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MEDIUM"
+                    }
+                },
+                "HIGH": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "HIGH"
+                    }
+                },
+                "VERY_HIGH": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "VERY_HIGH"
+                    }
+                },
+                "ONE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ONE"
+                    }
+                },
+                "TWO": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "TWO"
+                    }
+                },
+                "THREE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "THREE"
+                    }
+                },
+                "FOUR": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FOUR"
+                    }
+                },
+                "FIVE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FIVE"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#StringListAttributeBoostingConfiguration": {
+            "type": "structure",
+            "members": {
+                "boostingLevel": {
+                    "target": "com.amazonaws.qbusiness#DocumentAttributeBoostingLevel",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the priority of boosted document attributes in relation to other boosted attributes. This parameter determines how strongly the attribute influences document ranking in search results. <code>STRING_LIST</code> attributes can serve as additional boosting factors when needed, but are not supported when using <code>NativeIndexConfiguration</code> version 2.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides information on boosting <code>STRING_LIST</code> type document attributes.</p> <p>In the current boosting implementation, boosting focuses primarily on <code>DATE</code> attributes for recency and <code>STRING</code> attributes for source prioritization. <code>STRING_LIST</code> attributes can serve as additional boosting factors when needed, but are not supported when using <code>NativeIndexConfiguration</code> version 2.</p> <note> <p>For <code>STRING</code> and <code>STRING_LIST</code> type document attributes to be used for boosting on the console and the API, they must be enabled for search using the <a href=\"https://docs.aws.amazon.com/amazonq/latest/api-reference/API_DocumentAttributeConfiguration.html\">DocumentAttributeConfiguration</a> object of the <a href=\"https://docs.aws.amazon.com/amazonq/latest/api-reference/API_UpdateIndex.html\">UpdateIndex</a> API. If you haven't enabled searching on these attributes, you can't boost attributes of these data types on either the console or the API.</p> </note> <p>For more information on how boosting document attributes work in Amazon Q Business, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/business-use-dg/metadata-boosting.html\">Boosting using document attributes</a>.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#SubnetId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 200
+                },
+                "smithy.api#pattern": "^[-0-9a-zA-Z]+$"
+            }
+        },
+        "com.amazonaws.qbusiness#SubnetIds": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#SubnetId"
+            }
+        },
+        "com.amazonaws.qbusiness#Subscription": {
+            "type": "structure",
+            "members": {
+                "subscriptionId": {
+                    "target": "com.amazonaws.qbusiness#SubscriptionId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business subscription to be updated.</p>"
+                    }
+                },
+                "subscriptionArn": {
+                    "target": "com.amazonaws.qbusiness#SubscriptionArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon Q Business subscription that was updated.</p>"
+                    }
+                },
+                "principal": {
+                    "target": "com.amazonaws.qbusiness#SubscriptionPrincipal",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The IAM Identity Center <code>UserId</code> or <code>GroupId</code> of a user or group in the IAM Identity Center instance connected to the Amazon Q Business application.</p>"
+                    }
+                },
+                "currentSubscription": {
+                    "target": "com.amazonaws.qbusiness#SubscriptionDetails",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of your current Amazon Q Business subscription.</p>"
+                    }
+                },
+                "nextSubscription": {
+                    "target": "com.amazonaws.qbusiness#SubscriptionDetails",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the Amazon Q Business subscription for the next month.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about an Amazon Q Business subscription.</p> <p>Subscriptions are used to provide access for an IAM Identity Center user or a group to an Amazon Q Business application.</p> <p>Amazon Q Business offers two subscription tiers: <code>Q_LITE</code> and <code>Q_BUSINESS</code>. Subscription tier determines feature access for the user. For more information on subscriptions and pricing tiers, see <a href=\"https://aws.amazon.com/q/business/pricing/\">Amazon Q Business pricing</a>.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#SubscriptionArn": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 10,
+                    "max": 1224
+                },
+                "smithy.api#pattern": "^arn:[a-z0-9-\\.]{1,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}$"
+            }
+        },
+        "com.amazonaws.qbusiness#SubscriptionDetails": {
+            "type": "structure",
+            "members": {
+                "type": {
+                    "target": "com.amazonaws.qbusiness#SubscriptionType",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The type of an Amazon Q Business subscription. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p> The details of an Amazon Q Business subscription. </p>"
+            }
+        },
+        "com.amazonaws.qbusiness#SubscriptionId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 1224
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#SubscriptionPrincipal": {
+            "type": "union",
+            "members": {
+                "user": {
+                    "target": "com.amazonaws.qbusiness#UserIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of a user in the IAM Identity Center instance connected to the Amazon Q Business application.</p>"
+                    }
+                },
+                "group": {
+                    "target": "com.amazonaws.qbusiness#GroupIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of a group in the IAM Identity Center instance connected to the Amazon Q Business application.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A user or group in the IAM Identity Center instance connected to the Amazon Q Business application.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#SubscriptionType": {
+            "type": "enum",
+            "members": {
+                "Q_LITE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Q_LITE"
+                    }
+                },
+                "Q_BUSINESS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Q_BUSINESS"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#Subscriptions": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#Subscription"
+            }
+        },
+        "com.amazonaws.qbusiness#SyncSchedule": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "max": 998
+                },
+                "smithy.api#pattern": "^[\\s\\S]*$"
+            }
+        },
+        "com.amazonaws.qbusiness#SystemMessageId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 36,
+                    "max": 36
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{35}$"
+            }
+        },
+        "com.amazonaws.qbusiness#SystemMessageOverride": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "max": 350
+                },
+                "smithy.api#pattern": "^\\P{C}*$"
+            }
+        },
+        "com.amazonaws.qbusiness#SystemMessageType": {
+            "type": "enum",
+            "members": {
+                "RESPONSE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "RESPONSE"
+                    }
+                },
+                "GROUNDED_RESPONSE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "GROUNDED_RESPONSE"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#Tag": {
+            "type": "structure",
+            "members": {
+                "key": {
+                    "target": "com.amazonaws.qbusiness#TagKey",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The key for the tag. Keys are not case sensitive and must be unique for the Amazon Q Business application or data source.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "value": {
+                    "target": "com.amazonaws.qbusiness#TagValue",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The value associated with the tag. The value may be an empty string but it can't be null.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A list of key/value pairs that identify an index, FAQ, or data source. Tag keys and values can consist of Unicode letters, digits, white space, and any of the following symbols: _ . : / = + - @.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#TagKey": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 128
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#TagKeys": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#TagKey"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 200
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#TagResource": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#TagResourceRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#TagResourceResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#conditionKeys": [
+                    "aws:RequestTag/${TagKey}",
+                    "aws:TagKeys"
+                ],
+                "smithy.api#documentation": "<p>Adds the specified tag to the specified Amazon Q Business application or data source resource. If the tag already exists, the existing value is replaced with the new value.</p>",
+                "smithy.api#http": {
+                    "uri": "/v1/tags/{resourceARN}",
+                    "method": "POST"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#TagResourceRequest": {
+            "type": "structure",
+            "members": {
+                "resourceARN": {
+                    "target": "com.amazonaws.qbusiness#AmazonResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon Q Business application or data source to tag.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.qbusiness#Tags",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of tag keys to add to the Amazon Q Business application or data source. If a tag already exists, the existing value is replaced with the new value.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#TagResourceResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#TagValue": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 256
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#Tags": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#Tag"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 200
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#TextDocumentStatistics": {
+            "type": "structure",
+            "members": {
+                "indexedTextBytes": {
+                    "target": "com.amazonaws.qbusiness#IndexedTextBytes",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The total size, in bytes, of the indexed documents.</p>"
+                    }
+                },
+                "indexedTextDocumentCount": {
+                    "target": "com.amazonaws.qbusiness#IndexedTextDocument",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of text documents indexed.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides information about text documents in an index.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#TextInputEvent": {
+            "type": "structure",
+            "members": {
+                "userMessage": {
+                    "target": "com.amazonaws.qbusiness#UserMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A user message in a text message input event.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>An input event for a end user message in an Amazon Q Business web experience. </p>"
+            }
+        },
+        "com.amazonaws.qbusiness#TextOutputEvent": {
+            "type": "structure",
+            "members": {
+                "systemMessageType": {
+                    "target": "com.amazonaws.qbusiness#SystemMessageType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of AI-generated message in a <code>TextOutputEvent</code>. Amazon Q Business currently supports two types of messages:</p> <ul> <li> <p> <code>RESPONSE</code> - The Amazon Q Business system response.</p> </li> <li> <p> <code>GROUNDED_RESPONSE</code> - The corrected, hallucination-reduced, response returned by Amazon Q Business. Available only if hallucination reduction is supported and configured for the application and detected in the end user chat query by Amazon Q Business.</p> </li> </ul>"
+                    }
+                },
+                "conversationId": {
+                    "target": "com.amazonaws.qbusiness#ConversationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the conversation with which the text output event is associated.</p>"
+                    }
+                },
+                "userMessageId": {
+                    "target": "com.amazonaws.qbusiness#MessageId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of an end user message in a <code>TextOutputEvent</code>.</p>"
+                    }
+                },
+                "systemMessageId": {
+                    "target": "com.amazonaws.qbusiness#MessageId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of an AI-generated message in a <code>TextOutputEvent</code>.</p>"
+                    }
+                },
+                "systemMessage": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An AI-generated message in a <code>TextOutputEvent</code>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>An output event for an AI-generated response in an Amazon Q Business web experience.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#TextSegment": {
+            "type": "structure",
+            "members": {
+                "beginOffset": {
+                    "target": "com.amazonaws.qbusiness#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The zero-based location in the response string where the source attribution starts.</p>"
+                    }
+                },
+                "endOffset": {
+                    "target": "com.amazonaws.qbusiness#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The zero-based location in the response string where the source attribution ends.</p>"
+                    }
+                },
+                "snippetExcerpt": {
+                    "target": "com.amazonaws.qbusiness#SnippetExcerpt",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The relevant text excerpt from a source that was used to generate a citation text segment in an Amazon Q Business chat response.</p>"
+                    }
+                },
+                "mediaId": {
+                    "target": "com.amazonaws.qbusiness#SourceAttributionMediaId",
+                    "traits": {
+                        "smithy.api#deprecated": {
+                            "since": "2025-02-28",
+                            "message": "Deprecated in favor of using mediaId within the respective sourceDetails field."
+                        },
+                        "smithy.api#documentation": "<p>The identifier of the media object associated with the text segment in the source attribution.</p>"
+                    }
+                },
+                "mediaMimeType": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#deprecated": {
+                            "since": "2025-02-28",
+                            "message": "Deprecated in favor of using mediaMimeType within the respective sourceDetails field."
+                        },
+                        "smithy.api#documentation": "<p>The MIME type (image/png) of the media object associated with the text segment in the source attribution.</p>"
+                    }
+                },
+                "sourceDetails": {
+                    "target": "com.amazonaws.qbusiness#SourceDetails",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Source information for a segment of extracted text, including its media type.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides information about a text extract in a chat response that can be attributed to a source document.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#TextSegmentList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#TextSegment"
+            }
+        },
+        "com.amazonaws.qbusiness#ThrottlingException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.qbusiness#ErrorMessage",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The request was denied due to throttling. Reduce the number of requests and try again.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 429
+            }
+        },
+        "com.amazonaws.qbusiness#Timestamp": {
+            "type": "timestamp"
+        },
+        "com.amazonaws.qbusiness#Title": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1024
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#TopicConfiguration": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "com.amazonaws.qbusiness#TopicConfigurationName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A name for your topic control configuration.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.qbusiness#TopicDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A description for your topic control configuration. Use this to outline how the large language model (LLM) should use this topic control configuration.</p>"
+                    }
+                },
+                "exampleChatMessages": {
+                    "target": "com.amazonaws.qbusiness#ExampleChatMessages",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of example phrases that you expect the end user to use in relation to the topic.</p>"
+                    }
+                },
+                "rules": {
+                    "target": "com.amazonaws.qbusiness#Rules",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Rules defined for a topic configuration.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The topic specific controls configured for an Amazon Q Business application.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#TopicConfigurationName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 36
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{0,35}$"
+            }
+        },
+        "com.amazonaws.qbusiness#TopicConfigurations": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#TopicConfiguration"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "max": 10
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#TopicDescription": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 350
+                },
+                "smithy.api#pattern": "^\\P{C}*$"
+            }
+        },
+        "com.amazonaws.qbusiness#UntagResource": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#UntagResourceRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#UntagResourceResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#conditionKeys": [
+                    "aws:TagKeys"
+                ],
+                "smithy.api#documentation": "<p>Removes a tag from an Amazon Q Business application or a data source.</p>",
+                "smithy.api#http": {
+                    "uri": "/v1/tags/{resourceARN}",
+                    "method": "DELETE"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UntagResourceRequest": {
+            "type": "structure",
+            "members": {
+                "resourceARN": {
+                    "target": "com.amazonaws.qbusiness#AmazonResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon Q Business application, or data source to remove the tag from.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "tagKeys": {
+                    "target": "com.amazonaws.qbusiness#TagKeys",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of tag keys to remove from the Amazon Q Business application or data source. If a tag key does not exist on the resource, it is ignored.</p>",
+                        "smithy.api#httpQuery": "tagKeys",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UntagResourceResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdateApplication": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#UpdateApplicationRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#UpdateApplicationResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#requiredActions": [
+                    "qbusiness:GetApplication",
+                    "qbusiness:TagResource",
+                    "qbusiness:UntagResource",
+                    "qbusiness:ListTagsForResource",
+                    "iam:PassRole",
+                    "sso:CreateApplication",
+                    "sso:PutApplicationAuthenticationMethod",
+                    "sso:PutApplicationAccessScope",
+                    "sso:PutApplicationGrant",
+                    "sso:DeleteApplication",
+                    "sso:DescribeInstance"
+                ],
+                "smithy.api#documentation": "<p>Updates an existing Amazon Q Business application.</p> <note> <p>Amazon Q Business applications may securely transmit data for processing across Amazon Web Services Regions within your geography. For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/cross-region-inference.html\">Cross region inference in Amazon Q Business</a>.</p> </note> <note> <p>An Amazon Q Apps service-linked role will be created if it's absent in the Amazon Web Services account when <code>QAppsConfiguration</code> is enabled in the request. For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/using-service-linked-roles-qapps.html\">Using service-linked roles for Q Apps</a>. </p> </note>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}",
+                    "method": "PUT"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdateApplicationRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "identityCenterInstanceArn": {
+                    "target": "com.amazonaws.qbusiness#InstanceArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The Amazon Resource Name (ARN) of the IAM Identity Center instance you are either creating for—or connecting to—your Amazon Q Business application.</p>"
+                    }
+                },
+                "displayName": {
+                    "target": "com.amazonaws.qbusiness#ApplicationName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A name for the Amazon Q Business application.</p>"
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.qbusiness#Description",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A description for the Amazon Q Business application.</p>"
+                    }
+                },
+                "roleArn": {
+                    "target": "com.amazonaws.qbusiness#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An Amazon Web Services Identity and Access Management (IAM) role that gives Amazon Q Business permission to access Amazon CloudWatch logs and metrics.</p>"
+                    }
+                },
+                "attachmentsConfiguration": {
+                    "target": "com.amazonaws.qbusiness#AttachmentsConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An option to allow end users to upload files directly during chat.</p>"
+                    }
+                },
+                "qAppsConfiguration": {
+                    "target": "com.amazonaws.qbusiness#QAppsConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An option to allow end users to create and use Amazon Q Apps in the web experience.</p>"
+                    }
+                },
+                "personalizationConfiguration": {
+                    "target": "com.amazonaws.qbusiness#PersonalizationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configuration information about chat response personalization. For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/personalizing-chat-responses.html\">Personalizing chat responses</a>.</p>"
+                    }
+                },
+                "autoSubscriptionConfiguration": {
+                    "target": "com.amazonaws.qbusiness#AutoSubscriptionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An option to enable updating the default subscription type assigned to an Amazon Q Business application using IAM identity federation for user management.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdateApplicationResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdateChatControlsConfiguration": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#UpdateChatControlsConfigurationRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#UpdateChatControlsConfigurationResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Updates a set of chat controls configured for an existing Amazon Q Business application.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/chatcontrols",
+                    "method": "PATCH",
+                    "code": 200
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdateChatControlsConfigurationRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the application for which the chat controls are configured.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "clientToken": {
+                    "target": "com.amazonaws.qbusiness#ClientToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token that you provide to identify the request to update a Amazon Q Business application chat configuration.</p>",
+                        "smithy.api#idempotencyToken": {}
+                    }
+                },
+                "responseScope": {
+                    "target": "com.amazonaws.qbusiness#ResponseScope",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The response scope configured for your application. This determines whether your application uses its retrieval augmented generation (RAG) system to generate answers only from your enterprise data, or also uses the large language models (LLM) knowledge to respons to end user questions in chat.</p>"
+                    }
+                },
+                "orchestrationConfiguration": {
+                    "target": "com.amazonaws.qbusiness#OrchestrationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The chat response orchestration settings for your application.</p>"
+                    }
+                },
+                "blockedPhrasesConfigurationUpdate": {
+                    "target": "com.amazonaws.qbusiness#BlockedPhrasesConfigurationUpdate",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The phrases blocked from chat by your chat control configuration.</p>"
+                    }
+                },
+                "topicConfigurationsToCreateOrUpdate": {
+                    "target": "com.amazonaws.qbusiness#TopicConfigurations",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configured topic specific chat controls you want to update.</p>"
+                    }
+                },
+                "topicConfigurationsToDelete": {
+                    "target": "com.amazonaws.qbusiness#TopicConfigurations",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configured topic specific chat controls you want to delete.</p>"
+                    }
+                },
+                "creatorModeConfiguration": {
+                    "target": "com.amazonaws.qbusiness#CreatorModeConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configuration details for <code>CREATOR_MODE</code>.</p>"
+                    }
+                },
+                "hallucinationReductionConfiguration": {
+                    "target": "com.amazonaws.qbusiness#HallucinationReductionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The hallucination reduction settings for your application.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdateChatControlsConfigurationResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdateChatResponseConfiguration": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#UpdateChatResponseConfigurationRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#UpdateChatResponseConfigurationResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#iamAction": {
+                    "requiredActions": [
+                        "qbusiness:GetChatResponseConfiguration",
+                        "qbusiness:TagResource",
+                        "qbusiness:UntagResource",
+                        "qbusiness:ListTagsForResource"
+                    ]
+                },
+                "smithy.api#documentation": "<p>Updates an existing chat response configuration in an Amazon Q Business application. This operation allows administrators to modify configuration settings, display name, and response parameters to refine how the system generates responses.</p>",
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/applications/{applicationId}/chatresponseconfigurations/{chatResponseConfigurationId}"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdateChatResponseConfigurationRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the Amazon Q Business application containing the chat response configuration to update.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "chatResponseConfigurationId": {
+                    "target": "com.amazonaws.qbusiness#ChatResponseConfigurationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the chat response configuration to update within the specified application.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "displayName": {
+                    "target": "com.amazonaws.qbusiness#DisplayName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The new human-readable name to assign to the chat response configuration, making it easier to identify among multiple configurations.</p>"
+                    }
+                },
+                "responseConfigurations": {
+                    "target": "com.amazonaws.qbusiness#ResponseConfigurations",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The updated collection of response configuration settings that define how Amazon Q Business generates and formats responses to user queries.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "clientToken": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A unique, case-sensitive identifier to ensure idempotency of the request. This helps prevent the same update from being processed multiple times if retries occur.</p>",
+                        "smithy.api#idempotencyToken": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdateChatResponseConfigurationResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdateDataAccessor": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#UpdateDataAccessorRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#UpdateDataAccessorResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#requiredActions": [
+                    "qbusiness:GetDataAccessor",
+                    "qbusiness:TagResource",
+                    "qbusiness:UntagResource",
+                    "qbusiness:ListTagsForResource"
+                ],
+                "smithy.api#documentation": "<p>Updates an existing data accessor. This operation allows modifying the action configurations (the allowed actions and associated filters) and the display name of the data accessor. It does not allow changing the IAM role associated with the data accessor or other core properties of the data accessor.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/dataaccessors/{dataAccessorId}",
+                    "method": "PUT"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdateDataAccessorRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the Amazon Q Business application.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "dataAccessorId": {
+                    "target": "com.amazonaws.qbusiness#DataAccessorId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the data accessor to update.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "actionConfigurations": {
+                    "target": "com.amazonaws.qbusiness#ActionConfigurationList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The updated list of action configurations specifying the allowed actions and any associated filters.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "authenticationDetail": {
+                    "target": "com.amazonaws.qbusiness#DataAccessorAuthenticationDetail",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The updated authentication configuration details for the data accessor. This specifies how the ISV will authenticate when accessing data through this data accessor.</p>"
+                    }
+                },
+                "displayName": {
+                    "target": "com.amazonaws.qbusiness#DataAccessorName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The updated friendly name for the data accessor.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdateDataAccessorResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdateDataSource": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#UpdateDataSourceRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#UpdateDataSourceResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#requiredActions": [
+                    "qbusiness:GetDataSource",
+                    "qbusiness:TagResource",
+                    "qbusiness:UntagResource",
+                    "qbusiness:ListTagsForResource",
+                    "iam:PassRole"
+                ],
+                "smithy.api#documentation": "<p>Updates an existing Amazon Q Business data source connector.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/indices/{indexId}/datasources/{dataSourceId}",
+                    "method": "PUT"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdateDataSourceRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The identifier of the Amazon Q Business application the data source is attached to.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "indexId": {
+                    "target": "com.amazonaws.qbusiness#IndexId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the index attached to the data source connector.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "dataSourceId": {
+                    "target": "com.amazonaws.qbusiness#DataSourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the data source connector.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "displayName": {
+                    "target": "com.amazonaws.qbusiness#DataSourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A name of the data source connector.</p>"
+                    }
+                },
+                "configuration": {
+                    "target": "com.amazonaws.qbusiness#DataSourceConfiguration"
+                },
+                "vpcConfiguration": {
+                    "target": "com.amazonaws.qbusiness#DataSourceVpcConfiguration"
+                },
+                "description": {
+                    "target": "com.amazonaws.qbusiness#Description",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the data source connector.</p>"
+                    }
+                },
+                "syncSchedule": {
+                    "target": "com.amazonaws.qbusiness#SyncSchedule",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The chosen update frequency for your data source.</p>"
+                    }
+                },
+                "roleArn": {
+                    "target": "com.amazonaws.qbusiness#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of an IAM role with permission to access the data source and required resources.</p>"
+                    }
+                },
+                "documentEnrichmentConfiguration": {
+                    "target": "com.amazonaws.qbusiness#DocumentEnrichmentConfiguration"
+                },
+                "mediaExtractionConfiguration": {
+                    "target": "com.amazonaws.qbusiness#MediaExtractionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configuration for extracting information from media in documents for your data source.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdateDataSourceResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdateIndex": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#UpdateIndexRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#UpdateIndexResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#requiredActions": [
+                    "qbusiness:GetIndex",
+                    "qbusiness:TagResource",
+                    "qbusiness:UntagResource",
+                    "qbusiness:ListTagsForResource"
+                ],
+                "smithy.api#documentation": "<p>Updates an Amazon Q Business index.</p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/indices/{indexId}",
+                    "method": "PUT"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdateIndexRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application connected to the index.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "indexId": {
+                    "target": "com.amazonaws.qbusiness#IndexId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business index.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "displayName": {
+                    "target": "com.amazonaws.qbusiness#ApplicationName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Amazon Q Business index.</p>"
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.qbusiness#Description",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the Amazon Q Business index.</p>"
+                    }
+                },
+                "capacityConfiguration": {
+                    "target": "com.amazonaws.qbusiness#IndexCapacityConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The storage capacity units you want to provision for your Amazon Q Business index. You can add and remove capacity to fit your usage needs.</p>"
+                    }
+                },
+                "documentAttributeConfigurations": {
+                    "target": "com.amazonaws.qbusiness#DocumentAttributeConfigurations",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configuration information for document metadata or fields. Document metadata are fields or attributes associated with your documents. For example, the company department name associated with each document. For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/business-use-dg/doc-attributes-types.html#doc-attributes\">Understanding document attributes</a>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdateIndexResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdatePlugin": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#UpdatePluginRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#UpdatePluginResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#requiredActions": [
+                    "qbusiness:GetPlugin",
+                    "qbusiness:TagResource",
+                    "qbusiness:UntagResource",
+                    "qbusiness:ListTagsForResource",
+                    "iam:PassRole"
+                ],
+                "smithy.api#documentation": "<p>Updates an Amazon Q Business plugin.</p>",
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/applications/{applicationId}/plugins/{pluginId}"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdatePluginRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the application the plugin is attached to.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "pluginId": {
+                    "target": "com.amazonaws.qbusiness#PluginId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the plugin.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "displayName": {
+                    "target": "com.amazonaws.qbusiness#PluginName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the plugin.</p>"
+                    }
+                },
+                "state": {
+                    "target": "com.amazonaws.qbusiness#PluginState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status of the plugin. </p>"
+                    }
+                },
+                "serverUrl": {
+                    "target": "com.amazonaws.qbusiness#Url",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The source URL used for plugin configuration.</p>"
+                    }
+                },
+                "customPluginConfiguration": {
+                    "target": "com.amazonaws.qbusiness#CustomPluginConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configuration for a custom plugin.</p>"
+                    }
+                },
+                "authConfiguration": {
+                    "target": "com.amazonaws.qbusiness#PluginAuthConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The authentication configuration the plugin is using.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdatePluginResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdateRetriever": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#UpdateRetrieverRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#UpdateRetrieverResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#requiredActions": [
+                    "qbusiness:TagResource",
+                    "qbusiness:UntagResource",
+                    "qbusiness:ListTagsForResource",
+                    "qbusiness:GetRetriever",
+                    "iam:PassRole"
+                ],
+                "smithy.api#documentation": "<p>Updates the retriever used for your Amazon Q Business application.</p>",
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/applications/{applicationId}/retrievers/{retrieverId}"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdateRetrieverRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of your Amazon Q Business application.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "retrieverId": {
+                    "target": "com.amazonaws.qbusiness#RetrieverId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of your retriever.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "configuration": {
+                    "target": "com.amazonaws.qbusiness#RetrieverConfiguration"
+                },
+                "displayName": {
+                    "target": "com.amazonaws.qbusiness#RetrieverName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of your retriever.</p>"
+                    }
+                },
+                "roleArn": {
+                    "target": "com.amazonaws.qbusiness#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of an IAM role with permission to access the retriever and required resources. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdateRetrieverResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdateSubscription": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#UpdateSubscriptionRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#UpdateSubscriptionResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Updates the pricing tier for an Amazon Q Business subscription. Upgrades are instant. Downgrades apply at the start of the next month. Subscription tier determines feature access for the user. For more information on subscriptions and pricing tiers, see <a href=\"https://aws.amazon.com/q/business/pricing/\">Amazon Q Business pricing</a>.</p>",
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/applications/{applicationId}/subscriptions/{subscriptionId}"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdateSubscriptionRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application where the subscription update should take effect.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "subscriptionId": {
+                    "target": "com.amazonaws.qbusiness#SubscriptionId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business subscription to be updated.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "type": {
+                    "target": "com.amazonaws.qbusiness#SubscriptionType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the Amazon Q Business subscription to be updated.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdateSubscriptionResponse": {
+            "type": "structure",
+            "members": {
+                "subscriptionArn": {
+                    "target": "com.amazonaws.qbusiness#SubscriptionArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon Q Business subscription that was updated.</p>"
+                    }
+                },
+                "currentSubscription": {
+                    "target": "com.amazonaws.qbusiness#SubscriptionDetails",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of your current Amazon Q Business subscription.</p>"
+                    }
+                },
+                "nextSubscription": {
+                    "target": "com.amazonaws.qbusiness#SubscriptionDetails",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the Amazon Q Business subscription for the next month.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdateUser": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#UpdateUserRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#UpdateUserResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Updates a information associated with a user id.</p>",
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/applications/{applicationId}/users/{userId}"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdateUserRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the application the user is attached to.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "userId": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The email id attached to the user.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "userAliasesToUpdate": {
+                    "target": "com.amazonaws.qbusiness#UserAliases",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The user aliases attached to the user id that are to be updated.</p>"
+                    }
+                },
+                "userAliasesToDelete": {
+                    "target": "com.amazonaws.qbusiness#UserAliases",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The user aliases attached to the user id that are to be deleted.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdateUserResponse": {
+            "type": "structure",
+            "members": {
+                "userAliasesAdded": {
+                    "target": "com.amazonaws.qbusiness#UserAliases",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The user aliases that have been to be added to a user id.</p>"
+                    }
+                },
+                "userAliasesUpdated": {
+                    "target": "com.amazonaws.qbusiness#UserAliases",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The user aliases attached to a user id that have been updated.</p>"
+                    }
+                },
+                "userAliasesDeleted": {
+                    "target": "com.amazonaws.qbusiness#UserAliases",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The user aliases that have been deleted from a user id.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdateWebExperience": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.qbusiness#UpdateWebExperienceRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.qbusiness#UpdateWebExperienceResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.qbusiness#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.qbusiness#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.iam#requiredActions": [
+                    "qbusiness:GetWebExperience",
+                    "qbusiness:TagResource",
+                    "qbusiness:UntagResource",
+                    "qbusiness:ListTagsForResource",
+                    "iam:PassRole",
+                    "sso:PutApplicationGrant",
+                    "sso:UpdateApplication"
+                ],
+                "smithy.api#documentation": "<p>Updates an Amazon Q Business web experience. </p>",
+                "smithy.api#http": {
+                    "uri": "/applications/{applicationId}/experiences/{webExperienceId}",
+                    "method": "PUT"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdateWebExperienceRequest": {
+            "type": "structure",
+            "members": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business application attached to the web experience.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "webExperienceId": {
+                    "target": "com.amazonaws.qbusiness#WebExperienceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Amazon Q Business web experience.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "roleArn": {
+                    "target": "com.amazonaws.qbusiness#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the role with permission to access the Amazon Q Business web experience and required resources.</p>"
+                    }
+                },
+                "authenticationConfiguration": {
+                    "target": "com.amazonaws.qbusiness#WebExperienceAuthConfiguration",
+                    "traits": {
+                        "smithy.api#deprecated": {
+                            "message": "Property associated with legacy SAML IdP flow. Deprecated in favor of using AWS IAM Identity Center for user management."
+                        },
+                        "smithy.api#documentation": "<p>The authentication configuration of the Amazon Q Business web experience.</p>"
+                    }
+                },
+                "title": {
+                    "target": "com.amazonaws.qbusiness#WebExperienceTitle",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The title of the Amazon Q Business web experience.</p>"
+                    }
+                },
+                "subtitle": {
+                    "target": "com.amazonaws.qbusiness#WebExperienceSubtitle",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The subtitle of the Amazon Q Business web experience.</p>"
+                    }
+                },
+                "welcomeMessage": {
+                    "target": "com.amazonaws.qbusiness#WebExperienceWelcomeMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A customized welcome message for an end user in an Amazon Q Business web experience.</p>"
+                    }
+                },
+                "samplePromptsControlMode": {
+                    "target": "com.amazonaws.qbusiness#WebExperienceSamplePromptsControlMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Determines whether sample prompts are enabled in the web experience for an end user.</p>"
+                    }
+                },
+                "identityProviderConfiguration": {
+                    "target": "com.amazonaws.qbusiness#IdentityProviderConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the identity provider (IdP) used to authenticate end users of an Amazon Q Business web experience.</p>"
+                    }
+                },
+                "origins": {
+                    "target": "com.amazonaws.qbusiness#WebExperienceOrigins",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Updates the website domain origins that are allowed to embed the Amazon Q Business web experience. The <i>domain origin</i> refers to the <i>base URL</i> for accessing a website including the protocol (<code>http/https</code>), the domain name, and the port number (if specified).</p> <note> <ul> <li> <p>Any values except <code>null</code> submitted as part of this update will replace all previous values.</p> </li> <li> <p>You must only submit a <i>base URL</i> and not a full path. For example, <code>https://docs.aws.amazon.com</code>.</p> </li> </ul> </note>"
+                    }
+                },
+                "browserExtensionConfiguration": {
+                    "target": "com.amazonaws.qbusiness#BrowserExtensionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The browser extension configuration for an Amazon Q Business web experience.</p> <note> <p> For Amazon Q Business application using external OIDC-compliant identity providers (IdPs). The IdP administrator must add the browser extension sign-in redirect URLs to the IdP application. For more information, see <a href=\"https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/browser-extensions.html\">Configure external OIDC identity provider for your browser extensions.</a>. </p> </note>"
+                    }
+                },
+                "customizationConfiguration": {
+                    "target": "com.amazonaws.qbusiness#CustomizationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Updates the custom logo, favicon, font, and color used in the Amazon Q web experience. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.qbusiness#UpdateWebExperienceResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.qbusiness#Url": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 2048
+                },
+                "smithy.api#pattern": "^(https?|ftp|file)://([^\\s]*)$"
+            }
+        },
+        "com.amazonaws.qbusiness#UserAlias": {
+            "type": "structure",
+            "members": {
+                "indexId": {
+                    "target": "com.amazonaws.qbusiness#IndexId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the index that the user aliases are associated with.</p>"
+                    }
+                },
+                "dataSourceId": {
+                    "target": "com.amazonaws.qbusiness#DataSourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the data source that the user aliases are associated with.</p>"
+                    }
+                },
+                "userId": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the user id associated with the user aliases.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Aliases attached to a user id within an Amazon Q Business application.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#UserAliases": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#UserAlias"
+            }
+        },
+        "com.amazonaws.qbusiness#UserGroups": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#String"
+            }
+        },
+        "com.amazonaws.qbusiness#UserId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1024
+                },
+                "smithy.api#pattern": "^\\P{C}*$"
+            }
+        },
+        "com.amazonaws.qbusiness#UserIdentifier": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 47
+                },
+                "smithy.api#pattern": "^([0-9a-f]{10}-|)[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$"
+            }
+        },
+        "com.amazonaws.qbusiness#UserIds": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#String"
+            }
+        },
+        "com.amazonaws.qbusiness#UserMessage": {
+            "type": "string"
+        },
+        "com.amazonaws.qbusiness#UsersAndGroups": {
+            "type": "structure",
+            "members": {
+                "userIds": {
+                    "target": "com.amazonaws.qbusiness#UserIds",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The user ids associated with a topic control rule.</p>"
+                    }
+                },
+                "userGroups": {
+                    "target": "com.amazonaws.qbusiness#UserGroups",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The user group names associated with a topic control rule.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides information about users and group names associated with a topic control rule.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#ValidationException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.qbusiness#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The message describing the <code>ValidationException</code>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "reason": {
+                    "target": "com.amazonaws.qbusiness#ValidationExceptionReason",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The reason for the <code>ValidationException</code>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "fields": {
+                    "target": "com.amazonaws.qbusiness#ValidationExceptionFields",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The input field(s) that failed validation.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The input doesn't meet the constraints set by the Amazon Q Business service. Provide the correct input and try again.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.qbusiness#ValidationExceptionField": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The field name where the invalid entry was detected.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "message": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A message about the validation exception.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The input failed to meet the constraints specified by Amazon Q Business in a specified field.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#ValidationExceptionFields": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#ValidationExceptionField"
+            }
+        },
+        "com.amazonaws.qbusiness#ValidationExceptionReason": {
+            "type": "enum",
+            "members": {
+                "CANNOT_PARSE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CANNOT_PARSE"
+                    }
+                },
+                "FIELD_VALIDATION_FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FIELD_VALIDATION_FAILED"
+                    }
+                },
+                "UNKNOWN_OPERATION": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "UNKNOWN_OPERATION"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#VideoExtractionConfiguration": {
+            "type": "structure",
+            "members": {
+                "videoExtractionStatus": {
+                    "target": "com.amazonaws.qbusiness#VideoExtractionStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status of video extraction (ENABLED or DISABLED) for processing video content from files.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration settings for video content extraction and processing.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#VideoExtractionStatus": {
+            "type": "enum",
+            "members": {
+                "ENABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ENABLED"
+                    }
+                },
+                "DISABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DISABLED"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#VideoExtractionType": {
+            "type": "enum",
+            "members": {
+                "TRANSCRIPT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "TRANSCRIPT"
+                    }
+                },
+                "SUMMARY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SUMMARY"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#VideoSourceDetails": {
+            "type": "structure",
+            "members": {
+                "mediaId": {
+                    "target": "com.amazonaws.qbusiness#MediaId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Unique identifier for the video media file.</p>"
+                    }
+                },
+                "mediaMimeType": {
+                    "target": "com.amazonaws.qbusiness#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The MIME type of the video file (e.g., video/mp4, video/avi).</p>"
+                    }
+                },
+                "startTimeMilliseconds": {
+                    "target": "com.amazonaws.qbusiness#Long",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The starting timestamp in milliseconds for the relevant video segment.</p>"
+                    }
+                },
+                "endTimeMilliseconds": {
+                    "target": "com.amazonaws.qbusiness#Long",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ending timestamp in milliseconds for the relevant video segment.</p>"
+                    }
+                },
+                "videoExtractionType": {
+                    "target": "com.amazonaws.qbusiness#VideoExtractionType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of video extraction performed on the content.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Details about a video source, including its identifier, format, and time information.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#WebExperience": {
+            "type": "structure",
+            "members": {
+                "webExperienceId": {
+                    "target": "com.amazonaws.qbusiness#WebExperienceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of your Amazon Q Business web experience.</p>"
+                    }
+                },
+                "createdAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Unix timestamp when the Amazon Q Business application was last updated.</p>"
+                    }
+                },
+                "updatedAt": {
+                    "target": "com.amazonaws.qbusiness#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Unix timestamp when your Amazon Q Business web experience was updated.</p>"
+                    }
+                },
+                "defaultEndpoint": {
+                    "target": "com.amazonaws.qbusiness#Url",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The endpoint URLs for your Amazon Q Business web experience. The URLs are unique and fully hosted by Amazon Web Services.</p>"
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.qbusiness#WebExperienceStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status of your Amazon Q Business web experience.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides information for an Amazon Q Business web experience.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#WebExperienceArn": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 1284
+                },
+                "smithy.api#pattern": "^arn:[a-z0-9-\\.]{1,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}$"
+            }
+        },
+        "com.amazonaws.qbusiness#WebExperienceAuthConfiguration": {
+            "type": "union",
+            "members": {
+                "samlConfiguration": {
+                    "target": "com.amazonaws.qbusiness#SamlConfiguration"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides the authorization configuration information needed to deploy a Amazon Q Business web experience to end users.</p>"
+            }
+        },
+        "com.amazonaws.qbusiness#WebExperienceId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 36,
+                    "max": 36
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]*$"
+            }
+        },
+        "com.amazonaws.qbusiness#WebExperienceOrigins": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#Origin"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 10
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#WebExperienceResource": {
+            "type": "resource",
+            "identifiers": {
+                "applicationId": {
+                    "target": "com.amazonaws.qbusiness#ApplicationId"
+                },
+                "webExperienceId": {
+                    "target": "com.amazonaws.qbusiness#WebExperienceId"
+                }
+            },
+            "create": {
+                "target": "com.amazonaws.qbusiness#CreateWebExperience"
+            },
+            "read": {
+                "target": "com.amazonaws.qbusiness#GetWebExperience"
+            },
+            "update": {
+                "target": "com.amazonaws.qbusiness#UpdateWebExperience"
+            },
+            "delete": {
+                "target": "com.amazonaws.qbusiness#DeleteWebExperience"
+            },
+            "list": {
+                "target": "com.amazonaws.qbusiness#ListWebExperiences"
+            },
+            "traits": {
+                "aws.cloudformation#cfnResource": {
+                    "name": "WebExperience"
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#WebExperienceSamplePromptsControlMode": {
+            "type": "enum",
+            "members": {
+                "ENABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ENABLED"
+                    }
+                },
+                "DISABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DISABLED"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#WebExperienceStatus": {
+            "type": "enum",
+            "members": {
+                "CREATING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CREATING"
+                    }
+                },
+                "ACTIVE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ACTIVE"
+                    }
+                },
+                "DELETING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETING"
+                    }
+                },
+                "FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FAILED"
+                    }
+                },
+                "PENDING_AUTH_CONFIG": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PENDING_AUTH_CONFIG"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#WebExperienceSubtitle": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 500
+                },
+                "smithy.api#pattern": "^[\\s\\S]*$"
+            }
+        },
+        "com.amazonaws.qbusiness#WebExperienceTitle": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 500
+                },
+                "smithy.api#pattern": "^[\\s\\S]*$"
+            }
+        },
+        "com.amazonaws.qbusiness#WebExperienceWelcomeMessage": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 300
+                }
+            }
+        },
+        "com.amazonaws.qbusiness#WebExperiences": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.qbusiness#WebExperience"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds the Smithy model for the Amazon QBusiness service. This will enable us to automatically generate and publish the `aws-sdk-qbusiness` client in our next release. 

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
