### PR TITLE
Update links to use aws org instead of awslabs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,4 +56,4 @@ If you discover a potential security issue in this project we ask that you notif
 
 ## Licensing
 
-See the [LICENSE](https://github.com/awslabs/aws-sdk-python/blob/develop/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+See the [LICENSE](https://github.com/aws/aws-sdk-python/blob/develop/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Apache 2 licensed][apache-badge]][apache-url]
 
 [apache-badge]: https://img.shields.io/badge/license-APACHE2-blue.svg
-[apache-url]: https://github.com/awslabs/aws-sdk-python/blob/main/LICENSE
+[apache-url]: https://github.com/aws/aws-sdk-python/blob/main/LICENSE
 
 This repository contains experimental async clients for the AWS SDK for Python.
 These new clients will allow you to interact with select AWS services that can
@@ -26,12 +26,12 @@ The SDK uses **GitHub Issues** to track feature requests and issues with the SDK
 we intend to use **GitHub Projects** to provide a high level overview of our roadmap and the
 features we are actively working on.
 
-You can provide feedback or report a bug by submitting an [issue](https://github.com/awslabs/aws-sdk-python/issues/new/choose).
+You can provide feedback or report a bug by submitting an [issue](https://github.com/aws/aws-sdk-python/issues/new/choose).
 This is the preferred mechanism to give feedback so that other users can engage in the conversation, +1 issues, etc.
 
 ## Security
 
-See [CONTRIBUTING](https://github.com/awslabs/aws-sdk-python/blob/develop/CONTRIBUTING.md#security-issue-notifications) for more information.
+See [CONTRIBUTING](https://github.com/aws/aws-sdk-python/blob/develop/CONTRIBUTING.md#security-issue-notifications) for more information.
 
 ## License
 

--- a/clients/aws-sdk-bedrock-runtime/.changes/0.1.1.json
+++ b/clients/aws-sdk-bedrock-runtime/.changes/0.1.1.json
@@ -10,7 +10,7 @@
     },
     {
       "type": "enhancement",
-      "description": "Improvements to the underlying AWS CRT HTTP client result in a significant decrease in CPU usage. Addresses [aws-sdk-python#11](https://github.com/awslabs/aws-sdk-python/issues/11)."
+      "description": "Improvements to the underlying AWS CRT HTTP client result in a significant decrease in CPU usage. Addresses [aws-sdk-python#11](https://github.com/aws/aws-sdk-python/issues/11)."
     },
     {
       "type": "dependency",

--- a/clients/aws-sdk-bedrock-runtime/.changes/0.4.0.json
+++ b/clients/aws-sdk-bedrock-runtime/.changes/0.4.0.json
@@ -14,7 +14,7 @@
     },
     {
       "type": "enhancement",
-      "description": "Update package docstrings from Sphinx style to Google style for improved readability and consistency with Python community standards. ([#48](https://github.com/awslabs/aws-sdk-python/pull/48))"
+      "description": "Update package docstrings from Sphinx style to Google style for improved readability and consistency with Python community standards. ([#48](https://github.com/aws/aws-sdk-python/pull/48))"
     }
   ]
 }

--- a/clients/aws-sdk-bedrock-runtime/CHANGELOG.md
+++ b/clients/aws-sdk-bedrock-runtime/CHANGELOG.md
@@ -38,7 +38,7 @@
 
 ### Enhancements
 * Re-generated with smithy-python 0.3.0
-* Update package docstrings from Sphinx style to Google style for improved readability and consistency with Python community standards. ([#48](https://github.com/awslabs/aws-sdk-python/pull/48))
+* Update package docstrings from Sphinx style to Google style for improved readability and consistency with Python community standards. ([#48](https://github.com/aws/aws-sdk-python/pull/48))
 
 ## v0.3.0
 
@@ -81,7 +81,7 @@
 * Removed unused `serialize.py` and `deserialize.py` modules.
 
 ### Enhancements
-* Improvements to the underlying AWS CRT HTTP client result in a significant decrease in CPU usage. Addresses [aws-sdk-python#11](https://github.com/awslabs/aws-sdk-python/issues/11).
+* Improvements to the underlying AWS CRT HTTP client result in a significant decrease in CPU usage. Addresses [aws-sdk-python#11](https://github.com/aws/aws-sdk-python/issues/11).
 
 ### Dependencies
 * **Updated**: `smithy_http[awscrt]` from `~=0.1.0` to `~=0.2.0`.

--- a/clients/aws-sdk-bedrock-runtime/README.md
+++ b/clients/aws-sdk-bedrock-runtime/README.md
@@ -8,6 +8,6 @@ Changes may result in breaking changes prior to the release of version
 
 Documentation is available in the `/docs` directory of this package.
 Pages can be built into portable HTML files for the time being. You can
-follow the instructions in the docs [README.md](https://github.com/awslabs/aws-sdk-python/blob/main/clients/aws-sdk-bedrock-runtime/docs/README.md).
+follow the instructions in the docs [README.md](https://github.com/aws/aws-sdk-python/blob/main/clients/aws-sdk-bedrock-runtime/docs/README.md).
 
-For high-level documentation, you can view the [`dev-guide`](https://github.com/awslabs/aws-sdk-python/tree/main/dev-guide) at the top level of this repo.
+For high-level documentation, you can view the [`dev-guide`](https://github.com/aws/aws-sdk-python/tree/main/dev-guide) at the top level of this repo.

--- a/clients/aws-sdk-connecthealth/README.md
+++ b/clients/aws-sdk-connecthealth/README.md
@@ -9,6 +9,6 @@ Changes may result in breaking changes prior to the release of version
 
 Documentation is available in the `/docs` directory of this package.
 Pages can be built into portable HTML files for the time being. You can
-follow the instructions in the docs [README.md](https://github.com/awslabs/aws-sdk-python/blob/main/clients/aws-sdk-connecthealth/docs/README.md).
+follow the instructions in the docs [README.md](https://github.com/aws/aws-sdk-python/blob/main/clients/aws-sdk-connecthealth/docs/README.md).
 
-For high-level documentation, you can view the [`dev-guide`](https://github.com/awslabs/aws-sdk-python/tree/main/dev-guide) at the top level of this repo.
+For high-level documentation, you can view the [`dev-guide`](https://github.com/aws/aws-sdk-python/tree/main/dev-guide) at the top level of this repo.

--- a/clients/aws-sdk-lex-runtime-v2/README.md
+++ b/clients/aws-sdk-lex-runtime-v2/README.md
@@ -9,6 +9,6 @@ Changes may result in breaking changes prior to the release of version
 
 Documentation is available in the `/docs` directory of this package.
 Pages can be built into portable HTML files for the time being. You can
-follow the instructions in the docs [README.md](https://github.com/awslabs/aws-sdk-python/blob/main/clients/aws-sdk-lex-runtime-v2/docs/README.md).
+follow the instructions in the docs [README.md](https://github.com/aws/aws-sdk-python/blob/main/clients/aws-sdk-lex-runtime-v2/docs/README.md).
 
-For high-level documentation, you can view the [`dev-guide`](https://github.com/awslabs/aws-sdk-python/tree/main/dev-guide) at the top level of this repo.
+For high-level documentation, you can view the [`dev-guide`](https://github.com/aws/aws-sdk-python/tree/main/dev-guide) at the top level of this repo.

--- a/clients/aws-sdk-polly/README.md
+++ b/clients/aws-sdk-polly/README.md
@@ -9,6 +9,6 @@ Changes may result in breaking changes prior to the release of version
 
 Documentation is available in the `/docs` directory of this package.
 Pages can be built into portable HTML files for the time being. You can
-follow the instructions in the docs [README.md](https://github.com/awslabs/aws-sdk-python/blob/main/clients/aws-sdk-polly/docs/README.md).
+follow the instructions in the docs [README.md](https://github.com/aws/aws-sdk-python/blob/main/clients/aws-sdk-polly/docs/README.md).
 
-For high-level documentation, you can view the [`dev-guide`](https://github.com/awslabs/aws-sdk-python/tree/main/dev-guide) at the top level of this repo.
+For high-level documentation, you can view the [`dev-guide`](https://github.com/aws/aws-sdk-python/tree/main/dev-guide) at the top level of this repo.

--- a/clients/aws-sdk-qbusiness/README.md
+++ b/clients/aws-sdk-qbusiness/README.md
@@ -9,6 +9,6 @@ Changes may result in breaking changes prior to the release of version
 
 Documentation is available in the `/docs` directory of this package.
 Pages can be built into portable HTML files for the time being. You can
-follow the instructions in the docs [README.md](https://github.com/awslabs/aws-sdk-python/blob/main/clients/aws-sdk-qbusiness/docs/README.md).
+follow the instructions in the docs [README.md](https://github.com/aws/aws-sdk-python/blob/main/clients/aws-sdk-qbusiness/docs/README.md).
 
-For high-level documentation, you can view the [`dev-guide`](https://github.com/awslabs/aws-sdk-python/tree/main/dev-guide) at the top level of this repo.
+For high-level documentation, you can view the [`dev-guide`](https://github.com/aws/aws-sdk-python/tree/main/dev-guide) at the top level of this repo.

--- a/clients/aws-sdk-sagemaker-runtime-http2/.changes/0.4.0.json
+++ b/clients/aws-sdk-sagemaker-runtime-http2/.changes/0.4.0.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "type": "enhancement",
-      "description": "Update package docstrings from Sphinx style to Google style for improved readability and consistency with Python community standards. ([#48](https://github.com/awslabs/aws-sdk-python/pull/48))"
+      "description": "Update package docstrings from Sphinx style to Google style for improved readability and consistency with Python community standards. ([#48](https://github.com/aws/aws-sdk-python/pull/48))"
     },
     {
       "type": "enhancement",

--- a/clients/aws-sdk-sagemaker-runtime-http2/CHANGELOG.md
+++ b/clients/aws-sdk-sagemaker-runtime-http2/CHANGELOG.md
@@ -25,7 +25,7 @@
 ## v0.4.0
 
 ### Enhancements
-* Update package docstrings from Sphinx style to Google style for improved readability and consistency with Python community standards. ([#48](https://github.com/awslabs/aws-sdk-python/pull/48))
+* Update package docstrings from Sphinx style to Google style for improved readability and consistency with Python community standards. ([#48](https://github.com/aws/aws-sdk-python/pull/48))
 * Re-generated with smithy-python 0.3.0
 
 ## v0.3.0

--- a/clients/aws-sdk-sagemaker-runtime-http2/README.md
+++ b/clients/aws-sdk-sagemaker-runtime-http2/README.md
@@ -9,6 +9,6 @@ Changes may result in breaking changes prior to the release of version
 
 Documentation is available in the `/docs` directory of this package.
 Pages can be built into portable HTML files for the time being. You can
-follow the instructions in the docs [README.md](https://github.com/awslabs/aws-sdk-python/blob/main/clients/aws-sdk-sagemaker-runtime-http2/docs/README.md).
+follow the instructions in the docs [README.md](https://github.com/aws/aws-sdk-python/blob/main/clients/aws-sdk-sagemaker-runtime-http2/docs/README.md).
 
-For high-level documentation, you can view the [`dev-guide`](https://github.com/awslabs/aws-sdk-python/tree/main/dev-guide) at the top level of this repo.
+For high-level documentation, you can view the [`dev-guide`](https://github.com/aws/aws-sdk-python/tree/main/dev-guide) at the top level of this repo.

--- a/clients/aws-sdk-transcribe-streaming/.changes/0.4.0.json
+++ b/clients/aws-sdk-transcribe-streaming/.changes/0.4.0.json
@@ -6,7 +6,7 @@
     },
     {
       "type": "enhancement",
-      "description": "Update package docstrings from Sphinx style to Google style for improved readability and consistency with Python community standards. ([#48](https://github.com/awslabs/aws-sdk-python/pull/48))"
+      "description": "Update package docstrings from Sphinx style to Google style for improved readability and consistency with Python community standards. ([#48](https://github.com/aws/aws-sdk-python/pull/48))"
     }
   ]
 }

--- a/clients/aws-sdk-transcribe-streaming/CHANGELOG.md
+++ b/clients/aws-sdk-transcribe-streaming/CHANGELOG.md
@@ -29,7 +29,7 @@
 
 ### Enhancements
 * Re-generated with smithy-python 0.3.0
-* Update package docstrings from Sphinx style to Google style for improved readability and consistency with Python community standards. ([#48](https://github.com/awslabs/aws-sdk-python/pull/48))
+* Update package docstrings from Sphinx style to Google style for improved readability and consistency with Python community standards. ([#48](https://github.com/aws/aws-sdk-python/pull/48))
 
 ## v0.3.0
 

--- a/clients/aws-sdk-transcribe-streaming/README.md
+++ b/clients/aws-sdk-transcribe-streaming/README.md
@@ -8,9 +8,9 @@ Changes may result in breaking changes prior to the release of version
 
 Documentation is available in the `/docs` directory of this package.
 Pages can be built into portable HTML files for the time being. You can
-follow the instructions in the docs [README.md](https://github.com/awslabs/aws-sdk-python/blob/main/clients/aws-sdk-transcribe-streaming/docs/README.md).
+follow the instructions in the docs [README.md](https://github.com/aws/aws-sdk-python/blob/main/clients/aws-sdk-transcribe-streaming/docs/README.md).
 
-For high-level documentation, you can view the [`dev-guide`](https://github.com/awslabs/aws-sdk-python/tree/main/dev-guide) at the top level of this repo.
+For high-level documentation, you can view the [`dev-guide`](https://github.com/aws/aws-sdk-python/tree/main/dev-guide) at the top level of this repo.
 
 ### Examples
 

--- a/dev-guide/README.md
+++ b/dev-guide/README.md
@@ -2,7 +2,7 @@
 [![Apache 2 licensed][apache-badge]][apache-url]
 
 [apache-badge]: https://img.shields.io/badge/license-APACHE2-blue.svg
-[apache-url]: https://github.com/awslabs/aws-sdk-python/blob/main/LICENSE
+[apache-url]: https://github.com/aws/aws-sdk-python/blob/main/LICENSE
 
 This directory contains the Developer Guide for the experimental Amazon
 Bedrock Runtime client for Python.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: AWS SDK for Python
 site_description: Documentation for AWS SDK for Python Clients
 
-repo_name: awslabs/aws-sdk-python
-repo_url: https://github.com/awslabs/aws-sdk-python
+repo_name: aws/aws-sdk-python
+repo_url: https://github.com/aws/aws-sdk-python
 
 hooks:
   - docs/hooks/copyright.py
@@ -84,7 +84,7 @@ markdown_extensions:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/awslabs/aws-sdk-python
+      link: https://github.com/aws/aws-sdk-python
 
 extra_javascript:
   - path: javascript/nav-expand.js


### PR DESCRIPTION
## Summary

We transferred this repository from `awslabs/aws-sdk-python` to `aws/aws-sdk-python`.  This PR updates links to use `aws` org for GitHub links instead of `awslabs` for correctness. The old links still redirect to the new repo, so they aren't broken.

Note: The `<service_docs_path>/mkdocs.yml` will be updated at the infrastructure level.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
