### PR TITLE
Add new service clients to the AWS SDK Python meta-package

### DIFF
--- a/clients/aws-sdk-python/.changes/next-release/aws-sdk-python-enhancement-8325db4a415f43ae8255480038ec5259.json
+++ b/clients/aws-sdk-python/.changes/next-release/aws-sdk-python-enhancement-8325db4a415f43ae8255480038ec5259.json
@@ -1,0 +1,4 @@
+{
+  "type": "enhancement",
+  "description": "Add support for the following clients:\n  * aws_sdk_connecthealth\n  * aws_sdk_lex_runtime_v2\n  * aws_sdk_polly\n  * aws_sdk_qbusiness"
+}

--- a/clients/aws-sdk-python/pyproject.toml
+++ b/clients/aws-sdk-python/pyproject.toml
@@ -23,10 +23,19 @@ dependencies = []
 
 [project.optional-dependencies]
 bedrock_runtime = ["aws_sdk_bedrock_runtime==0.7.0"]
+connecthealth = ["aws_sdk_connecthealth==0.7.0"]
+lex_runtime_v2 = ["aws_sdk_lex_runtime_v2==0.7.0"]
+polly = ["aws_sdk_polly==0.7.0"]
+qbusiness = ["aws_sdk_qbusiness==0.7.0"]
 sagemaker_runtime_http2 = ["aws_sdk_sagemaker_runtime_http2==0.7.0"]
 transcribe_streaming = ["aws_sdk_transcribe_streaming==0.7.0"]
+
 all = [
     "aws_sdk_python[bedrock_runtime]",
+    "aws_sdk_python[connecthealth]",
+    "aws_sdk_python[lex_runtime_v2]",
+    "aws_sdk_python[polly]",
+    "aws_sdk_python[qbusiness]",
     "aws_sdk_python[sagemaker_runtime_http2]",
     "aws_sdk_python[transcribe_streaming]",
 ]


### PR DESCRIPTION
> [!NOTE]
> We need to implement a permanent fix for this at our infrastructure layer. I cannot prioritize that at the moment and will just manually update instead for now. Our automation does know how to bump known clients, but not add new ones.

## Overview
This PR adds optional dependencies for the Connect Health, Lex Runtime V2, Polly, and Q Business clients to the `aws_sdk_python` meta-package.

## Background
These clients are available as version `0.7.0` packages but were not installable through the meta-package’s service-specific or aggregate extras. The meta packages exposed optional dependency groups to allow for users to more easily install multiple compatible services together (e.g., `aws-sdk-python[bedrock-runtime, polly]`.

## Summary
* Add extras for:
  * `connecthealth`
  * `lex_runtime_v2`
  * `polly`
  * `qbusiness`
* Include the new extras in `aws_sdk_python[all]`.
* Add an enhancement changelog entry.

## Testing
Verified that the generated wheel metadata contains the new dependencies and correctly expands the `all` extra.

```
(aws-sdk-python) $ uv pip install -e ".[all]"
Resolved 16 packages in 1.17s
      Built aws-sdk-python @ file:///Users/gytndd/dev/GitHub/aws-sdk-python/clients/aws-sdk-python
Prepared 1 package in 130ms
Installed 16 packages in 1.71s
 + aws-sdk-bedrock-runtime==0.7.0
 + aws-sdk-connecthealth==0.7.0
 + aws-sdk-lex-runtime-v2==0.7.0
 + aws-sdk-polly==0.7.0
 + aws-sdk-python==0.7.0 (from file:///Users/gytndd/dev/GitHub/aws-sdk-python/clients/aws-sdk-python)
 + aws-sdk-qbusiness==0.7.0
 + aws-sdk-sagemaker-runtime-http2==0.7.0
 + aws-sdk-signers==0.3.0
 + aws-sdk-transcribe-streaming==0.7.0
 + awscrt==0.32.2
 + ijson==3.5.1
 + smithy-aws-core==0.7.0
 + smithy-aws-event-stream==0.3.0
 + smithy-core==0.6.0
 + smithy-http==0.4.2
 + smithy-json==0.2.3
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
