### PR TITLE
Use compatible version constraints for service clients

### DIFF
--- a/clients/aws-sdk-python/.changes/next-release/aws-sdk-python-dependency-compatible-client-constraints.json
+++ b/clients/aws-sdk-python/.changes/next-release/aws-sdk-python-dependency-compatible-client-constraints.json
@@ -1,0 +1,4 @@
+{
+  "type": "dependency",
+  "description": "Allow service clients to use newer compatible patch releases within the same minor version."
+}

--- a/clients/aws-sdk-python/.changes/next-release/aws-sdk-python-enhancement-8325db4a415f43ae8255480038ec5259.json
+++ b/clients/aws-sdk-python/.changes/next-release/aws-sdk-python-enhancement-8325db4a415f43ae8255480038ec5259.json
@@ -1,4 +1,4 @@
 {
-  "type": "enhancement",
+  "type": "dependency",
   "description": "Add support for the following clients:\n  * aws_sdk_connecthealth\n  * aws_sdk_lex_runtime_v2\n  * aws_sdk_polly\n  * aws_sdk_qbusiness"
 }

--- a/clients/aws-sdk-python/pyproject.toml
+++ b/clients/aws-sdk-python/pyproject.toml
@@ -22,13 +22,13 @@ classifiers = [
 dependencies = []
 
 [project.optional-dependencies]
-bedrock_runtime = ["aws_sdk_bedrock_runtime==0.7.0"]
-connecthealth = ["aws_sdk_connecthealth==0.7.0"]
-lex_runtime_v2 = ["aws_sdk_lex_runtime_v2==0.7.0"]
-polly = ["aws_sdk_polly==0.7.0"]
-qbusiness = ["aws_sdk_qbusiness==0.7.0"]
-sagemaker_runtime_http2 = ["aws_sdk_sagemaker_runtime_http2==0.7.0"]
-transcribe_streaming = ["aws_sdk_transcribe_streaming==0.7.0"]
+bedrock_runtime = ["aws_sdk_bedrock_runtime~=0.7.0"]
+connecthealth = ["aws_sdk_connecthealth~=0.7.0"]
+lex_runtime_v2 = ["aws_sdk_lex_runtime_v2~=0.7.0"]
+polly = ["aws_sdk_polly~=0.7.0"]
+qbusiness = ["aws_sdk_qbusiness~=0.7.0"]
+sagemaker_runtime_http2 = ["aws_sdk_sagemaker_runtime_http2~=0.7.0"]
+transcribe_streaming = ["aws_sdk_transcribe_streaming~=0.7.0"]
 
 all = [
     "aws_sdk_python[bedrock_runtime]",


### PR DESCRIPTION
## Summary

This PR replaces exact client pins with `~=`, matching our compatibility guarantee that clients within the same minor line work together. Customers can receive patch fixes without waiting for a meta-package release, while newer minor versions remain excluded to prevent incompatible minor upgrades.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
