### PR TITLE
Use modeled SDK IDs for service names in top-level docs

### DIFF
--- a/scripts/docs/generate_all_doc_stubs.py
+++ b/scripts/docs/generate_all_doc_stubs.py
@@ -15,6 +15,8 @@ from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
 
+from utils import get_sdk_id
+
 logging.basicConfig(
     level=logging.INFO,
     format="[%(asctime)s - %(name)s - %(levelname)s] %(message)s",
@@ -35,12 +37,13 @@ class ClientInfo:
     path_name: str
 
 
-def discover_clients(clients_dir: Path) -> list[ClientInfo]:
+def discover_clients(clients_dir: Path, models_dir: Path) -> list[ClientInfo]:
     """
     Discover all clients that have a generate_doc_stubs.py script.
 
     Args:
         clients_dir: Path to the clients directory.
+        models_dir: Path to the Smithy models directory.
 
     Returns:
         List of ClientInfo objects.
@@ -54,10 +57,9 @@ def discover_clients(clients_dir: Path) -> list[ClientInfo]:
         if not script_path.exists():
             continue
 
-        # Convert "aws-sdk-bedrock-runtime" -> "Bedrock Runtime" / "bedrock-runtime"
         package_name = client_dir.name
         path_name = package_name.replace("aws-sdk-", "")
-        service_name = path_name.replace("-", " ").title()
+        service_name = get_sdk_id(models_dir / f"{path_name}.json")
         clients.append(ClientInfo(client_dir, service_name, package_name, path_name))
 
     return clients
@@ -197,9 +199,10 @@ def main() -> int:
     repo_root = Path(__file__).parent.parent.parent
     clients_dir = repo_root / "clients"
     docs_dir = repo_root / "docs"
+    models_dir = repo_root / "codegen" / "aws-models"
 
     try:
-        clients = discover_clients(clients_dir)
+        clients = discover_clients(clients_dir, models_dir)
 
         if not generate_all_doc_stubs(clients, docs_dir):
             return 1

--- a/scripts/docs/generate_nav.py
+++ b/scripts/docs/generate_nav.py
@@ -11,6 +11,8 @@ import sys
 
 from pathlib import Path
 
+from utils import get_sdk_id
+
 
 logging.basicConfig(
     level=logging.INFO,
@@ -33,6 +35,7 @@ def generate_nav(repo_root: Path) -> bool:
     logger.info("⏳ Generating navigation structure...")
 
     clients_dir = repo_root / "clients"
+    models_dir = repo_root / "codegen" / "aws-models"
     if not clients_dir.exists():
         logger.error(f"Clients directory not found: {clients_dir}")
         return False
@@ -44,16 +47,13 @@ def generate_nav(repo_root: Path) -> bool:
         "* [Available Clients](clients/index.md)",
     ]
 
-    # Discover clients and add each as a nested item under Available Clients
     client_count = 0
     for client_path in sorted(clients_dir.iterdir()):
         if not (client_path / "scripts" / "docs" / "generate_doc_stubs.py").exists():
             continue
 
-        # Extract service name and path from package name
-        # (e.g., "aws-sdk-bedrock-runtime" -> "Bedrock Runtime" / "bedrock-runtime")
         path_name = client_path.name.replace("aws-sdk-", "")
-        display_name = path_name.replace("-", " ").title()
+        display_name = get_sdk_id(models_dir / f"{path_name}.json")
 
         lines.append(f"    * [{display_name}](clients/{path_name}/index.md)")
         logger.info(f"Discovered client: {display_name}")

--- a/scripts/docs/utils.py
+++ b/scripts/docs/utils.py
@@ -1,0 +1,32 @@
+"""Utilities for reading service metadata from Smithy models."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+_AWS_SERVICE_TRAIT = "aws.api#service"
+
+
+def get_sdk_id(model_path: Path) -> str:
+    """Return the SDK ID from the service shape in a Smithy model."""
+    model: dict[str, Any] = json.loads(model_path.read_text())
+    service_shapes = [
+        shape
+        for shape in model.get("shapes", {}).values()
+        if shape.get("type") == "service"
+    ]
+
+    if len(service_shapes) != 1:
+        raise ValueError(
+            f"Expected exactly one service shape in {model_path}, "
+            f"found {len(service_shapes)}"
+        )
+
+    sdk_id = (
+        service_shapes[0].get("traits", {}).get(_AWS_SERVICE_TRAIT, {}).get("sdkId")
+    )
+    if not isinstance(sdk_id, str) or not sdk_id:
+        raise ValueError(f"Missing {_AWS_SERVICE_TRAIT}.sdkId in {model_path}")
+
+    return sdk_id


### PR DESCRIPTION
## Summary

There are three locations in our API Reference site where service names have incorrect capitalization:
- [Available Clients](https://docs.aws.amazon.com/sdk-for-python/v1/reference/clients/)
- Left navigation sidebar list under "Available Clients"
- Page title in service-level pages (e.g. [Sns](https://docs.aws.amazon.com/sdk-for-python/v1/reference/clients/sns/))

This PR fixes the first two locations. Service-level page titles are generated by the nested client documentation scripts and require a corresponding change in the upstream infrastructure layer.

## Current Behavior

The top-level documentation scripts derive service names from package directory names using Python’s `.title()` method.

For example, `aws-sdk-sts` becomes `Sts`, despite the Smithy model defining its SDK ID as `STS`.

## New Behavior

The top-level documentation scripts now read the official `sdkId` from each service’s Smithy model under `codegen/aws-models/`.

These modeled names are used for:

- The Available Clients page
- The left navigation sidebar
- Documentation-generation log messages

URLs and package names remain unchanged.

## Examples

| Current | New |
|---|---|
| `Api Gateway` | `API Gateway` |
| `Bedrock Agentcore` | `Bedrock AgentCore` |
| `Bedrock Agentcore Control` | `Bedrock AgentCore Control` |
| `Connecthealth` | `ConnectHealth` |
| `Guardduty` | `GuardDuty` |
| `Qbusiness` | `QBusiness` |
| `Sagemaker Runtime Http2` | `SageMaker Runtime HTTP2` |
| `Sns` | `SNS` |
| `Sts` | `STS` |


## Testing

- Generated the top-level navigation for all 18 clients.
- Verified modeled names including API Gateway, SNS, and STS.
- Verified the updated scripts compile successfully.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
