### PR TITLE
Add new clients to the meta-package

### DIFF
--- a/clients/aws-sdk-python/.changes/next-release/aws-sdk-python-dependency-86dbd876e29b4c5cbcf27c7781d08190.json
+++ b/clients/aws-sdk-python/.changes/next-release/aws-sdk-python-dependency-86dbd876e29b4c5cbcf27c7781d08190.json
@@ -1,0 +1,4 @@
+{
+  "type": "dependency",
+  "description": "Add support for the following clients:\n  * `aws-sdk-api-gateway`\n  * `aws-sdk-bedrock`\n  * `aws-sdk-bedrock-agent`\n  * `aws-sdk-bedrock-agent-runtime`\n  * `aws-sdk-bedrock-agentcore`\n  * `aws-sdk-bedrock-agentcore-control`\n  * `aws-sdk-bedrock-data-automation`\n  * `aws-sdk-guardduty`\n  * `aws-sdk-lambda`\n  * `aws-sdk-sns`\n  * `aws-sdk-sts`"
+}

--- a/clients/aws-sdk-python/pyproject.toml
+++ b/clients/aws-sdk-python/pyproject.toml
@@ -22,21 +22,43 @@ classifiers = [
 dependencies = []
 
 [project.optional-dependencies]
+api_gateway = ["aws_sdk_api_gateway~=0.8.0"]
+bedrock = ["aws_sdk_bedrock~=0.8.0"]
+bedrock_agent = ["aws_sdk_bedrock_agent~=0.8.0"]
+bedrock_agent_runtime = ["aws_sdk_bedrock_agent_runtime~=0.8.0"]
+bedrock_agentcore = ["aws_sdk_bedrock_agentcore~=0.8.0"]
+bedrock_agentcore_control = ["aws_sdk_bedrock_agentcore_control~=0.8.0"]
+bedrock_data_automation = ["aws_sdk_bedrock_data_automation~=0.8.0"]
 bedrock_runtime = ["aws_sdk_bedrock_runtime~=0.8.0"]
 connecthealth = ["aws_sdk_connecthealth~=0.8.0"]
+guardduty = ["aws_sdk_guardduty~=0.8.0"]
+lambda = ["aws_sdk_lambda~=0.8.0"]
 lex_runtime_v2 = ["aws_sdk_lex_runtime_v2~=0.8.0"]
 polly = ["aws_sdk_polly~=0.8.0"]
 qbusiness = ["aws_sdk_qbusiness~=0.8.0"]
 sagemaker_runtime_http2 = ["aws_sdk_sagemaker_runtime_http2~=0.8.0"]
+sns = ["aws_sdk_sns~=0.8.0"]
+sts = ["aws_sdk_sts~=0.8.0"]
 transcribe_streaming = ["aws_sdk_transcribe_streaming~=0.8.0"]
 
 all = [
+    "aws_sdk_python[api_gateway]",
+    "aws_sdk_python[bedrock]",
+    "aws_sdk_python[bedrock_agent]",
+    "aws_sdk_python[bedrock_agent_runtime]",
+    "aws_sdk_python[bedrock_agentcore]",
+    "aws_sdk_python[bedrock_agentcore_control]",
+    "aws_sdk_python[bedrock_data_automation]",
     "aws_sdk_python[bedrock_runtime]",
     "aws_sdk_python[connecthealth]",
+    "aws_sdk_python[guardduty]",
+    "aws_sdk_python[lambda]",
     "aws_sdk_python[lex_runtime_v2]",
     "aws_sdk_python[polly]",
     "aws_sdk_python[qbusiness]",
     "aws_sdk_python[sagemaker_runtime_http2]",
+    "aws_sdk_python[sns]",
+    "aws_sdk_python[sts]",
     "aws_sdk_python[transcribe_streaming]",
 ]
 


### PR DESCRIPTION
> [!NOTE]
> We need to implement a permanent fix for this at our infrastructure layer. I cannot prioritize that at the moment and will just manually update instead for now. Our automation does know how to bump known clients, but not add new ones.

## Overview
This PR adds optional dependencies for the 11 new services released on 2026-07-31 to the `aws-sdk-python` meta-package.

## Background
These clients are available as version `0.8.0` packages but were not installable through the meta-package’s service-specific or aggregate extras. The meta packages exposed optional dependency groups to allow for users to more easily install multiple compatible services together (e.g., `aws-sdk-python[bedrock-runtime, polly]`.

## Summary
* Add extras for:
  * `api_gateway`
  * `bedrock`
  * `bedrock_agent`
  * `bedrock_agent_runtime`
  * `bedrock_agentcore`
  * bedrock_agentcore_control`
  * `bedrock_data_automation`
  * `guardduty`
  * `lambda`
  * `sns`
  * `sts`
* Include the new extras in `aws_sdk_python[all]`.
* Add a `dependency` changelog entry.

## Testing
Verified that the generated wheel metadata contains the new dependencies and correctly expands the `all` extra.

```
$ uv venv
Using CPython 3.14.6
Creating virtual environment at: .venv
Activate with: source .venv/bin/activate
$ . .venv/bin/activate
(aws-sdk-python) $ uv pip install -e ".[all]"
Resolved 37 packages in 989ms
      Built aws-sdk-python @ file:///Users/gytndd/dev/GitHub/aws-sdk-python/clients/aws-sdk-python                       Prepared 1 package in 117ms
Installed 37 packages in 3.96s
 + aiohappyeyeballs==2.7.1
 + aiohttp==3.14.3
 + aiosignal==1.4.0
 + attrs==26.1.0
 + aws-sdk-api-gateway==0.8.0
 + aws-sdk-bedrock==0.8.0
 + aws-sdk-bedrock-agent==0.8.0
 + aws-sdk-bedrock-agent-runtime==0.8.0
 + aws-sdk-bedrock-agentcore==0.8.0
 + aws-sdk-bedrock-agentcore-control==0.8.0
 + aws-sdk-bedrock-data-automation==0.8.0
 + aws-sdk-bedrock-runtime==0.8.0
 + aws-sdk-connecthealth==0.8.0
 + aws-sdk-guardduty==0.8.0
 + aws-sdk-lambda==0.8.0
 + aws-sdk-lex-runtime-v2==0.8.0
 + aws-sdk-polly==0.8.0
 + aws-sdk-python==0.8.0 (from file:///Users/gytndd/dev/GitHub/aws-sdk-python/clients/aws-sdk-python)
 + aws-sdk-qbusiness==0.8.0
 + aws-sdk-sagemaker-runtime-http2==0.8.0
 + aws-sdk-signers==0.3.0
 + aws-sdk-sns==0.8.0
 + aws-sdk-sts==0.8.0
 + aws-sdk-transcribe-streaming==0.8.0                                                                                    
 + awscrt==0.32.2
 + frozenlist==1.8.0                                                                                                      
 + idna==3.18                                                                                                             
 + ijson==3.5.1
 + multidict==6.7.1
 + propcache==0.5.2
 + smithy-aws-core==0.8.0
 + smithy-aws-event-stream==0.3.0
 + smithy-core==0.7.0
 + smithy-http==0.4.3
 + smithy-json==0.2.3
 + smithy-xml==0.1.0
 + yarl==1.24.5
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.