### PR TITLE
Update STS client to use new async config and fix failing container resolver tests

### DIFF
--- a/packages/aws-credentials-http/.changes/next-release/aws-credentials-http-bugfix-bd4ef625870a44faa848494a7489ad19.json
+++ b/packages/aws-credentials-http/.changes/next-release/aws-credentials-http-bugfix-bd4ef625870a44faa848494a7489ad19.json
@@ -1,0 +1,4 @@
+{
+  "type": "bugfix",
+  "description": "Normalize empty container credential URI query strings to `None`."
+}

--- a/packages/aws-credentials-http/src/aws_credentials_http/resolvers.py
+++ b/packages/aws-credentials-http/src/aws_credentials_http/resolvers.py
@@ -95,7 +95,7 @@ class ContainerCredentialsResolver(
                 host=parsed.hostname or "",
                 port=parsed.port,
                 path=parsed.path,
-                query=parsed.query,
+                query=parsed.query or None,
             )
         else:
             raise SmithyIdentityError(

--- a/packages/aws-credentials-http/tests/unit/test_resolvers.py
+++ b/packages/aws-credentials-http/tests/unit/test_resolvers.py
@@ -74,6 +74,35 @@ async def test_resolver_env_full() -> None:
     )
     http_request = http_client.send.call_args_list[0].args[0]
     assert http_request.destination == expected_url
+    assert http_request.destination.query is None
+    _assert_expected_identity(identity)
+
+
+async def test_resolver_env_full_with_query() -> None:
+    response_body = json.dumps(DEFAULT_RESPONSE_DATA)
+    http_client = mock_http_client_response(200, response_body.encode())
+
+    with patch.dict(
+        os.environ,
+        {
+            ContainerCredentialsResolver.ENV_VAR_FULL: (
+                "http://169.254.170.23/full?role=task%2Fworker&version=1"
+            )
+        },
+        clear=True,
+    ):
+        resolver = ContainerCredentialsResolver(http_client)
+        identity = await resolver.get_identity(properties={})
+
+    expected_url = URI(
+        scheme="http",
+        host="169.254.170.23",
+        path="/full",
+        query="role=task%2Fworker&version=1",
+    )
+    http_request = http_client.send.call_args_list[0].args[0]
+    assert http_request.destination == expected_url
+    assert http_request.destination.query == "role=task%2Fworker&version=1"
     _assert_expected_identity(identity)
 
 

--- a/packages/aws-credentials-sts/.changes/next-release/aws-credentials-sts-dependency-f1c7b755958249a394c8fad72970ff83.json
+++ b/packages/aws-credentials-sts/.changes/next-release/aws-credentials-sts-dependency-f1c7b755958249a394c8fad72970ff83.json
@@ -1,0 +1,4 @@
+{
+  "type": "dependency",
+  "description": "Update STS credential resolution to use the new async client configuration API."
+}

--- a/packages/aws-credentials-sts/src/aws_credentials_sts/resolvers.py
+++ b/packages/aws-credentials-sts/src/aws_credentials_sts/resolvers.py
@@ -126,16 +126,18 @@ class AssumeRoleCredentialsResolver(
 
     async def _assume_role(self) -> AWSCredentialsIdentity:
         from aws_sdk_sts.client import AsyncSTSClient
-        from aws_sdk_sts.config import Config
+        from aws_sdk_sts.config import AsyncSTSConfig
         from aws_sdk_sts.models import AssumeRoleInput
 
         if self._client is None:
+            overrides: dict[str, object] = {
+                "aws_credentials_identity_resolver": self._source_resolver,
+                "region": self._region,
+            }
+            if self._http_client is not None:
+                overrides["transport"] = self._http_client
             self._client = AsyncSTSClient(
-                config=Config(
-                    aws_credentials_identity_resolver=self._source_resolver,
-                    region=self._region,
-                    transport=self._http_client,
-                )
+                config=await AsyncSTSConfig.resolve(**overrides)
             )
 
         response = await self._client.assume_role(


### PR DESCRIPTION
### Description

This PR makes two small runtime package updates:

#### `aws-credentials-sts`: adopts new async config API
Updates `AssumeRoleCredentialsResolver` to build its `AsyncSTSClient` from `AsyncSTSConfig.resolve(...)` instead of the deprecated synchronous `Config`. Config overrides (source credentials resolver, region, and optional transport) are now assembled into a dict and resolved asynchronously, with `transport` only set when an HTTP client is provided.

> [!WARNING]
>  This depends on the parallel `smithy-python` change that deprecates the old `Config` in favor of `AsyncSTSConfig` (https://github.com/smithy-lang/smithy-python/pull/758). It **must be sim-shipped in the same release** as that PR; releasing independently will break `aws-credentials-sts` (`ImportError: cannot import name 'AsyncSTSConfig'`).

#### `aws-credentials-http`: normalize empty query strings
Fixes `ContainerCredentialsResolver` to pass `query=parsed.query or None` when resolving from `AWS_CONTAINER_CREDENTIALS_FULL_URI`. `urlparse` yields `''` for a query-less URL, and the current `URI` no longer normalizes that to `None`, so the constructed request URI didn't match expectations.

### Testing

Ran the container credentials resolver unit tests standalone:
```shell
cd packages/aws-credentials-http
uv run --no-project --python 3.12 \
  --with pytest --with pytest-asyncio \
  --with-editable . \
  python -m pytest tests/unit/test_resolvers.py -o asyncio_mode=auto
```
All 12 tests pass, including the four `test_resolver_env_*` cases that previously failed on the empty-query-string mismatch.

9 `aws-credentials-sts` resolver tests currently fail with `ImportError: cannot import name 'AsyncSTSConfig' from 'aws_sdk_sts.config'` until smithy-python#758 ships the new async config. Nothing to do here until that lands; they'll pass once the two are released together.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
