### PR TITLE
Use async configs in integ tests and examples

### DIFF
--- a/clients/aws-sdk-bedrock-runtime/tests/integration/__init__.py
+++ b/clients/aws-sdk-bedrock-runtime/tests/integration/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from smithy_aws_core.identity import EnvironmentCredentialsResolver
 
 from aws_sdk_bedrock_runtime.client import BedrockRuntimeClient
-from aws_sdk_bedrock_runtime.config import Config
+from aws_sdk_bedrock_runtime.config import AsyncBedrockRuntimeConfig
 
 MODEL_ID = "global.amazon.nova-2-lite-v1:0"
 BIDIRECTIONAL_MODEL_ID = "amazon.nova-2-sonic-v1:0"
@@ -15,10 +15,10 @@ MESSAGE = "Who created the Python programming language?"
 AUDIO_FILE = Path(__file__).parent / "assets" / "test.pcm"
 
 
-def create_bedrock_client(region: str) -> BedrockRuntimeClient:
+async def create_bedrock_client(region: str) -> BedrockRuntimeClient:
     """Helper to create a BedrockRuntimeClient for a given region."""
     return BedrockRuntimeClient(
-        config=Config(
+        config=await AsyncBedrockRuntimeConfig.resolve(
             endpoint_uri=f"https://bedrock-runtime.{region}.amazonaws.com",
             region=region,
             aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),

--- a/clients/aws-sdk-bedrock-runtime/tests/integration/test_bidirectional_streaming.py
+++ b/clients/aws-sdk-bedrock-runtime/tests/integration/test_bidirectional_streaming.py
@@ -244,7 +244,7 @@ async def _receive_stream_output(
 
 async def test_invoke_model_with_bidirectional_stream() -> None:
     """Test bidirectional streaming with audio input and text/audio output."""
-    bedrock_client = create_bedrock_client("us-east-1")
+    bedrock_client = await create_bedrock_client("us-east-1")
 
     stream = await bedrock_client.invoke_model_with_bidirectional_stream(
         InvokeModelWithBidirectionalStreamOperationInput(

--- a/clients/aws-sdk-bedrock-runtime/tests/integration/test_non_streaming.py
+++ b/clients/aws-sdk-bedrock-runtime/tests/integration/test_non_streaming.py
@@ -15,7 +15,7 @@ from . import MESSAGE, MODEL_ID, create_bedrock_client
 
 
 async def test_converse() -> None:
-    bedrock_client = create_bedrock_client("us-west-2")
+    bedrock_client = await create_bedrock_client("us-west-2")
 
     input_message = Message(role="user", content=[ContentBlockText(value=MESSAGE)])
     response = await bedrock_client.converse(

--- a/clients/aws-sdk-bedrock-runtime/tests/integration/test_output_streaming.py
+++ b/clients/aws-sdk-bedrock-runtime/tests/integration/test_output_streaming.py
@@ -17,7 +17,7 @@ from . import MESSAGE, MODEL_ID, create_bedrock_client
 
 
 async def test_converse_stream() -> None:
-    bedrock_client = create_bedrock_client("us-west-2")
+    bedrock_client = await create_bedrock_client("us-west-2")
 
     input_message = Message(role="user", content=[ContentBlockText(value=MESSAGE)])
     response = await bedrock_client.converse_stream(

--- a/clients/aws-sdk-connecthealth/tests/integration/__init__.py
+++ b/clients/aws-sdk-connecthealth/tests/integration/__init__.py
@@ -6,15 +6,15 @@ from pathlib import Path
 from smithy_aws_core.identity import EnvironmentCredentialsResolver
 
 from aws_sdk_connecthealth.client import ConnectHealthClient
-from aws_sdk_connecthealth.config import Config, Plugin
+from aws_sdk_connecthealth.config import AsyncConnectHealthConfig, Plugin
 
 REGION = "us-east-1"
 AUDIO_FILE = Path(__file__).parent / "assets" / "test.wav"
 
 
-def create_connecthealth_client(region: str) -> ConnectHealthClient:
+async def create_connecthealth_client(region: str) -> ConnectHealthClient:
     return ConnectHealthClient(
-        config=Config(
+        config=await AsyncConnectHealthConfig.resolve(
             endpoint_uri=f"https://health-agent.{region}.api.aws",
             region=region,
             aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
@@ -26,7 +26,7 @@ def streaming_endpoint_plugin(region: str) -> Plugin:
     """Per-operation plugin that routes to the ``streaming.`` host prefix."""
     streaming_uri = f"https://streaming.health-agent.{region}.api.aws"
 
-    def _plugin(config: Config) -> None:
+    def _plugin(config: AsyncConnectHealthConfig) -> None:
         config.endpoint_uri = streaming_uri
 
     return _plugin

--- a/clients/aws-sdk-connecthealth/tests/integration/conftest.py
+++ b/clients/aws-sdk-connecthealth/tests/integration/conftest.py
@@ -153,7 +153,7 @@ async def connecthealth_resources():
     bucket_name = f"integ-test-connecthealth-bucket-{unique_suffix}"
 
     s3_client = boto3.client("s3", region_name=REGION)
-    client = create_connecthealth_client(REGION)
+    client = await create_connecthealth_client(REGION)
 
     domain_id: str | None = None
     subscription_id: str | None = None

--- a/clients/aws-sdk-connecthealth/tests/integration/test_bidirectional_streaming.py
+++ b/clients/aws-sdk-connecthealth/tests/integration/test_bidirectional_streaming.py
@@ -157,7 +157,7 @@ async def test_start_medical_scribe_listening_session(connecthealth_resources) -
     """Test bidirectional streaming with audio input and transcript output."""
     domain_id, subscription_id, output_s3_uri = connecthealth_resources
 
-    client = create_connecthealth_client(REGION)
+    client = await create_connecthealth_client(REGION)
     endpoint_plugin = streaming_endpoint_plugin(REGION)
     session_id = str(uuid.uuid4())
 

--- a/clients/aws-sdk-connecthealth/tests/integration/test_non_streaming.py
+++ b/clients/aws-sdk-connecthealth/tests/integration/test_non_streaming.py
@@ -23,7 +23,7 @@ from . import REGION, create_connecthealth_client
 async def test_list_domains(connecthealth_resources) -> None:
     """Test non-streaming ListDomains operation."""
     _ = connecthealth_resources
-    client = create_connecthealth_client(REGION)
+    client = await create_connecthealth_client(REGION)
 
     response = await client.list_domains(input=ListDomainsInput())
 
@@ -35,7 +35,7 @@ async def test_list_domains(connecthealth_resources) -> None:
 async def test_get_domain(connecthealth_resources) -> None:
     """Test non-streaming GetDomain operation."""
     domain_id, _, _ = connecthealth_resources
-    client = create_connecthealth_client(REGION)
+    client = await create_connecthealth_client(REGION)
 
     response = await client.get_domain(input=GetDomainInput(domain_id=domain_id))
 
@@ -54,7 +54,7 @@ async def test_get_domain(connecthealth_resources) -> None:
 async def test_list_subscriptions(connecthealth_resources) -> None:
     """Test non-streaming ListSubscriptions operation."""
     domain_id, subscription_id, _ = connecthealth_resources
-    client = create_connecthealth_client(REGION)
+    client = await create_connecthealth_client(REGION)
 
     response = await client.list_subscriptions(
         input=ListSubscriptionsInput(domain_id=domain_id)
@@ -72,7 +72,7 @@ async def test_list_subscriptions(connecthealth_resources) -> None:
 async def test_get_subscription(connecthealth_resources) -> None:
     """Test non-streaming GetSubscription operation."""
     domain_id, subscription_id, _ = connecthealth_resources
-    client = create_connecthealth_client(REGION)
+    client = await create_connecthealth_client(REGION)
 
     response = await client.get_subscription(
         input=GetSubscriptionInput(domain_id=domain_id, subscription_id=subscription_id)

--- a/clients/aws-sdk-lex-runtime-v2/tests/integration/__init__.py
+++ b/clients/aws-sdk-lex-runtime-v2/tests/integration/__init__.py
@@ -4,16 +4,16 @@
 from smithy_aws_core.identity import EnvironmentCredentialsResolver
 
 from aws_sdk_lex_runtime_v2.client import LexRuntimeV2Client
-from aws_sdk_lex_runtime_v2.config import Config
+from aws_sdk_lex_runtime_v2.config import AsyncLexRuntimeV2Config
 
 BOT_ALIAS_ID = "TSTALIASID"
 LOCALE_ID = "en_US"
 REGION = "us-east-1"
 
 
-def create_lex_client(region: str) -> LexRuntimeV2Client:
+async def create_lex_client(region: str) -> LexRuntimeV2Client:
     return LexRuntimeV2Client(
-        config=Config(
+        config=await AsyncLexRuntimeV2Config.resolve(
             endpoint_uri=f"https://runtime-v2-lex.{region}.amazonaws.com",
             region=region,
             aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),

--- a/clients/aws-sdk-lex-runtime-v2/tests/integration/test_bidirectional_streaming.py
+++ b/clients/aws-sdk-lex-runtime-v2/tests/integration/test_bidirectional_streaming.py
@@ -125,7 +125,7 @@ async def _receive_events(
 
 async def test_start_conversation(lex_bot: str) -> None:
     """Test bidirectional streaming StartConversation operation."""
-    client = create_lex_client(REGION)
+    client = await create_lex_client(REGION)
 
     stream = await client.start_conversation(
         input=StartConversationInput(

--- a/clients/aws-sdk-lex-runtime-v2/tests/integration/test_non_streaming.py
+++ b/clients/aws-sdk-lex-runtime-v2/tests/integration/test_non_streaming.py
@@ -11,7 +11,7 @@ from . import BOT_ALIAS_ID, LOCALE_ID, REGION, create_lex_client
 
 async def test_recognize_text(lex_bot: str) -> None:
     """Test non-streaming RecognizeText operation."""
-    client = create_lex_client(REGION)
+    client = await create_lex_client(REGION)
     response = await client.recognize_text(
         input=RecognizeTextInput(
             bot_id=lex_bot,

--- a/clients/aws-sdk-polly/examples/stream_speech_to_file.py
+++ b/clients/aws-sdk-polly/examples/stream_speech_to_file.py
@@ -36,7 +36,7 @@ from smithy_aws_core.identity import EnvironmentCredentialsResolver
 from smithy_core.aio.interfaces.eventstream import EventPublisher, EventReceiver
 
 from aws_sdk_polly.client import PollyClient
-from aws_sdk_polly.config import Config
+from aws_sdk_polly.config import AsyncPollyConfig
 from aws_sdk_polly.models import (
     CloseStreamEvent,
     StartSpeechSynthesisStreamActionStream,
@@ -133,7 +133,7 @@ async def main():
     text_chunks = get_text_chunks(args.text)
 
     client = PollyClient(
-        config=Config(
+        config=await AsyncPollyConfig.resolve(
             endpoint_uri=f"https://polly.{args.region}.amazonaws.com",
             region=args.region,
             aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),

--- a/clients/aws-sdk-polly/examples/stream_speech_to_speakers.py
+++ b/clients/aws-sdk-polly/examples/stream_speech_to_speakers.py
@@ -40,7 +40,7 @@ from smithy_aws_core.identity import EnvironmentCredentialsResolver
 from smithy_core.aio.interfaces.eventstream import EventPublisher, EventReceiver
 
 from aws_sdk_polly.client import PollyClient
-from aws_sdk_polly.config import Config
+from aws_sdk_polly.config import AsyncPollyConfig
 from aws_sdk_polly.models import (
     CloseStreamEvent,
     StartSpeechSynthesisStreamActionStream,
@@ -239,7 +239,7 @@ async def main():
     text_chunks = get_text_chunks(args.text)
 
     client = PollyClient(
-        config=Config(
+        config=await AsyncPollyConfig.resolve(
             endpoint_uri=f"https://polly.{args.region}.amazonaws.com",
             region=args.region,
             aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),

--- a/clients/aws-sdk-polly/tests/integration/__init__.py
+++ b/clients/aws-sdk-polly/tests/integration/__init__.py
@@ -4,7 +4,7 @@
 from smithy_aws_core.identity import EnvironmentCredentialsResolver
 
 from aws_sdk_polly.client import PollyClient
-from aws_sdk_polly.config import Config
+from aws_sdk_polly.config import AsyncPollyConfig
 
 REGION = "us-east-1"
 VOICE_ID = "Matthew"
@@ -14,10 +14,10 @@ SAMPLE_RATE = "24000"
 TEST_TEXT = "Hello from the AWS SDK for Python Polly integration tests."
 
 
-def create_polly_client(region: str) -> PollyClient:
+async def create_polly_client(region: str) -> PollyClient:
     """Helper to create a PollyClient for a given region."""
     return PollyClient(
-        config=Config(
+        config=await AsyncPollyConfig.resolve(
             endpoint_uri=f"https://polly.{region}.amazonaws.com",
             region=region,
             aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),

--- a/clients/aws-sdk-polly/tests/integration/test_bidirectional_streaming.py
+++ b/clients/aws-sdk-polly/tests/integration/test_bidirectional_streaming.py
@@ -96,7 +96,7 @@ async def _receive_audio(
 
 async def test_start_speech_synthesis_stream() -> None:
     """Test bidirectional streaming with text input and audio output."""
-    client = create_polly_client(REGION)
+    client = await create_polly_client(REGION)
 
     stream = await client.start_speech_synthesis_stream(
         input=StartSpeechSynthesisStreamInput(

--- a/clients/aws-sdk-polly/tests/integration/test_non_streaming.py
+++ b/clients/aws-sdk-polly/tests/integration/test_non_streaming.py
@@ -10,7 +10,7 @@ from . import ENGINE, REGION, VOICE_ID, create_polly_client
 
 async def test_describe_voices() -> None:
     """Test non-streaming DescribeVoices operation."""
-    client = create_polly_client(REGION)
+    client = await create_polly_client(REGION)
 
     response = await client.describe_voices(input=DescribeVoicesInput(engine=ENGINE))
 

--- a/clients/aws-sdk-polly/tests/integration/test_output_streaming.py
+++ b/clients/aws-sdk-polly/tests/integration/test_output_streaming.py
@@ -20,7 +20,7 @@ from . import (
 
 async def test_synthesize_speech() -> None:
     """Test output-streaming SynthesizeSpeech operation."""
-    client = create_polly_client(REGION)
+    client = await create_polly_client(REGION)
 
     response = await client.synthesize_speech(
         input=SynthesizeSpeechInput(

--- a/clients/aws-sdk-qbusiness/tests/integration/__init__.py
+++ b/clients/aws-sdk-qbusiness/tests/integration/__init__.py
@@ -4,15 +4,15 @@
 from smithy_aws_core.identity import EnvironmentCredentialsResolver
 
 from aws_sdk_qbusiness.client import QBusinessClient
-from aws_sdk_qbusiness.config import Config
+from aws_sdk_qbusiness.config import AsyncQBusinessConfig
 
 REGION = "us-east-1"
 
 
-def create_qbusiness_client(region: str) -> QBusinessClient:
+async def create_qbusiness_client(region: str) -> QBusinessClient:
     """Helper to create a QBusinessClient for a given region."""
     return QBusinessClient(
-        config=Config(
+        config=await AsyncQBusinessConfig.resolve(
             endpoint_uri=f"https://qbusiness.{region}.api.aws",
             region=region,
             aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),

--- a/clients/aws-sdk-qbusiness/tests/integration/conftest.py
+++ b/clients/aws-sdk-qbusiness/tests/integration/conftest.py
@@ -207,7 +207,7 @@ async def qbusiness_app():
     index_name = f"integ-test-qbusiness-index-{unique_suffix}"
     retriever_name = f"integ-test-qbusiness-retriever-{unique_suffix}"
 
-    client = create_qbusiness_client(REGION)
+    client = await create_qbusiness_client(REGION)
     application_id: str | None = None
     try:
         application_id = await _create_qbusiness_app(

--- a/clients/aws-sdk-qbusiness/tests/integration/test_bidirectional_streaming.py
+++ b/clients/aws-sdk-qbusiness/tests/integration/test_bidirectional_streaming.py
@@ -94,7 +94,7 @@ async def _receive_chat_output(
 
 async def test_chat_bidirectional_streaming(qbusiness_app: str) -> None:
     """Test bidirectional streaming with text input and chat output."""
-    qbusiness_client = create_qbusiness_client(REGION)
+    qbusiness_client = await create_qbusiness_client(REGION)
 
     stream = await qbusiness_client.chat(
         input=ChatInput(application_id=qbusiness_app, client_token=str(uuid.uuid4()))

--- a/clients/aws-sdk-qbusiness/tests/integration/test_non_streaming.py
+++ b/clients/aws-sdk-qbusiness/tests/integration/test_non_streaming.py
@@ -12,7 +12,7 @@ from . import REGION, create_qbusiness_client
 
 async def test_chat_sync(qbusiness_app: str) -> None:
     """Test non-streaming ChatSync operation."""
-    qbusiness_client = create_qbusiness_client(REGION)
+    qbusiness_client = await create_qbusiness_client(REGION)
 
     response = await qbusiness_client.chat_sync(
         input=ChatSyncInput(

--- a/clients/aws-sdk-transcribe-streaming/examples/simple_file.py
+++ b/clients/aws-sdk-transcribe-streaming/examples/simple_file.py
@@ -37,7 +37,7 @@ from aws_sdk_transcribe_streaming.client import (
     StartStreamTranscriptionInput,
     TranscribeStreamingClient,
 )
-from aws_sdk_transcribe_streaming.config import Config
+from aws_sdk_transcribe_streaming.config import AsyncTranscribeStreamingConfig
 from aws_sdk_transcribe_streaming.models import (
     AudioEvent,
     AudioStream,
@@ -118,7 +118,7 @@ async def write_chunks(audio_stream: EventPublisher[AudioStream]):
 async def main():
     # Initialize the Transcribe Streaming client
     client = TranscribeStreamingClient(
-        config=Config(
+        config=await AsyncTranscribeStreamingConfig.resolve(
             endpoint_uri=ENDPOINT_URI,
             region=AWS_REGION,
             aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),

--- a/clients/aws-sdk-transcribe-streaming/examples/simple_mic.py
+++ b/clients/aws-sdk-transcribe-streaming/examples/simple_mic.py
@@ -37,7 +37,7 @@ from aws_sdk_transcribe_streaming.client import (
     StartStreamTranscriptionInput,
     TranscribeStreamingClient,
 )
-from aws_sdk_transcribe_streaming.config import Config
+from aws_sdk_transcribe_streaming.config import AsyncTranscribeStreamingConfig
 from aws_sdk_transcribe_streaming.models import (
     AudioEvent,
     AudioStream,
@@ -116,7 +116,7 @@ async def write_chunks(audio_stream: EventPublisher[AudioStream]):
 async def main():
     # Initialize the Transcribe Streaming client
     client = TranscribeStreamingClient(
-        config=Config(
+        config=await AsyncTranscribeStreamingConfig.resolve(
             endpoint_uri=ENDPOINT_URI,
             region=AWS_REGION,
             aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),

--- a/clients/aws-sdk-transcribe-streaming/tests/integration/__init__.py
+++ b/clients/aws-sdk-transcribe-streaming/tests/integration/__init__.py
@@ -6,15 +6,15 @@ from pathlib import Path
 from smithy_aws_core.identity import EnvironmentCredentialsResolver
 
 from aws_sdk_transcribe_streaming.client import TranscribeStreamingClient
-from aws_sdk_transcribe_streaming.config import Config
+from aws_sdk_transcribe_streaming.config import AsyncTranscribeStreamingConfig
 
 AUDIO_FILE = Path(__file__).parent / "assets" / "test.wav"
 
 
-def create_transcribe_client(region: str) -> TranscribeStreamingClient:
+async def create_transcribe_client(region: str) -> TranscribeStreamingClient:
     """Helper to create a TranscribeStreamingClient for a given region."""
     return TranscribeStreamingClient(
-        config=Config(
+        config=await AsyncTranscribeStreamingConfig.resolve(
             endpoint_uri=f"https://transcribestreaming.{region}.amazonaws.com",
             region=region,
             aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),

--- a/clients/aws-sdk-transcribe-streaming/tests/integration/test_bidirectional_streaming.py
+++ b/clients/aws-sdk-transcribe-streaming/tests/integration/test_bidirectional_streaming.py
@@ -88,7 +88,7 @@ async def _receive_transcription_output(
 
 async def test_start_stream_transcription() -> None:
     """Test bidirectional streaming with audio input and transcription output."""
-    transcribe_client = create_transcribe_client("us-west-2")
+    transcribe_client = await create_transcribe_client("us-west-2")
 
     stream = await transcribe_client.start_stream_transcription(
         input=StartStreamTranscriptionInput(

--- a/clients/aws-sdk-transcribe-streaming/tests/integration/test_non_streaming.py
+++ b/clients/aws-sdk-transcribe-streaming/tests/integration/test_non_streaming.py
@@ -43,7 +43,7 @@ ROLE_PROPAGATION_RETRY_DELAY = 5
 
 async def _run_medical_scribe_session(role_arn: str, s3_bucket: str) -> None:
     """Run a full Medical Scribe streaming session and verify its completion."""
-    transcribe_client = create_transcribe_client("us-east-1")
+    transcribe_client = await create_transcribe_client("us-east-1")
     session_id = str(uuid.uuid4())
 
     stream = await transcribe_client.start_medical_scribe_stream(


### PR DESCRIPTION
This PR updates all integration tests and examples to use the new async-resolved config classes instead of the deprecated `Config` constructor:

```python
config=await AsyncPollyConfig.resolve(...)  # was: config=Config(...)
```

Client-creation helpers are now `async` and all call sites `await` them.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
